### PR TITLE
chore: add CODEOWNERS for repository

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,7 @@
+# AgentScope repository code owners
+# For more information, see:
+#   https://docs.github.com/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners
+
+# Default code owners: every file in the repository requires approval
+# from at least one of the following users.
+*  @purvanshjoshi @archittmittal


### PR DESCRIPTION
## Summary

Adds a \.github/CODEOWNERS\ file so code reviews are automatically assigned to the repository's maintainers.

## Changes

- Adds \/ .github/CODEOWNERS\ with a default rule covering all paths, owned by:
  - \@purvanshjoshi\
  - \@archittmittal\

## Notes

- The path-based labeler (ci/cd) will apply automatically since the file lives under \.github/\.