### PR TITLE
fix: implement session status patch retry queue and implicit sync

### DIFF
--- a/packages/sdk/agentscope/client.py
+++ b/packages/sdk/agentscope/client.py
@@ -31,6 +31,7 @@ class AgentScopeClient:
         )
         self.session_metadata = session_metadata or {}
         self.session_id: Optional[str] = None
+        self.pending_status: Optional[str] = None
         self.queue: queue.Queue = queue.Queue(maxsize=5000)
         self.thread: Optional[threading.Thread] = None
         self.loop: Optional[asyncio.AbstractEventLoop] = None
@@ -79,17 +80,22 @@ class AgentScopeClient:
                     self.queue.task_done()
                 except queue.Empty:
                     pass
-
     def patch_session_status(self, status: str) -> None:
         """Update the session status on the server.
 
         Args:
             status: "completed" or "failed"
         """
-        if not self.session_id:
-            return
+        with self._lock:
+            if not self.session_id:
+                self.pending_status = status
+                return
+            session_id = self.session_id
 
-        url = f"http://{self.host}:{self.port}/sessions/{self.session_id}"
+        self._send_status_patch(session_id, status)
+
+    def _send_status_patch(self, session_id: str, status: str) -> None:
+        url = f"http://{self.host}:{self.port}/sessions/{session_id}"
         data = json.dumps(
             {
                 "status": status,
@@ -108,7 +114,7 @@ class AgentScopeClient:
             try:
                 with urllib.request.urlopen(req, timeout=5):
                     logging.info(
-                        f"AgentScope session {self.session_id} "
+                        f"AgentScope session {session_id} "
                         f"patched to status: {status}"
                     )
             except Exception as e:
@@ -122,7 +128,6 @@ class AgentScopeClient:
             name="AgentScopeSessionPatchThread",
             daemon=True,
         ).start()
-
     def _run_loop(self) -> None:
         self.loop = asyncio.new_event_loop()
         asyncio.set_event_loop(self.loop)
@@ -227,9 +232,19 @@ class AgentScopeClient:
         try:
             with urllib.request.urlopen(req, timeout=5) as response:
                 res_data = json.loads(response.read().decode("utf-8"))
-                self.session_id = res_data.get("session_id")
-                logging.info(
-                    f"AgentScope session successfully registered. ID: {self.session_id}"
-                )
+                new_session_id = res_data.get("session_id")
+
+                status_to_patch = None
+                with self._lock:
+                    self.session_id = new_session_id
+                    logging.info(
+                        f"AgentScope session successfully registered. ID: {self.session_id}"
+                    )
+                    if self.pending_status:
+                        status_to_patch = self.pending_status
+                        self.pending_status = None
+
+                if status_to_patch:
+                    self._send_status_patch(new_session_id, status_to_patch)
         except Exception as e:
             logging.warning(f"Failed to register session with AgentScope server: {e}")

--- a/packages/sdk/tests/test_sdk.py
+++ b/packages/sdk/tests/test_sdk.py
@@ -80,3 +80,46 @@ async def test_callback_handler():
     assert len(emitted) == 2
     assert emitted[1]["event_type"] == "chain_end"
     callback.client.patch_session_status.assert_called_once_with("completed")
+
+
+def test_client_pending_status_patch():
+    from unittest.mock import MagicMock
+    from agentscope.client import AgentScopeClient
+
+    client = AgentScopeClient(host="localhost", port=8765, session_name="test_session")
+    # session_id is initially None
+    assert client.session_id is None
+    assert client.pending_status is None
+
+    # Call patch_session_status when session_id is not set yet
+    client.patch_session_status("completed")
+
+    # Verify that status is enqueued in pending_status
+    assert client.pending_status == "completed"
+
+    # Mock _send_status_patch
+    client._send_status_patch = MagicMock()
+
+    # Mock urllib.request.urlopen to simulate successful session creation
+    import urllib.request
+    from io import BytesIO
+
+    mock_response = BytesIO(b'{"session_id": "test-uuid-123"}')
+    original_urlopen = urllib.request.urlopen
+    urllib.request.urlopen = MagicMock(return_value=mock_response)
+
+    try:
+        # Trigger creation
+        client._create_session_sync()
+
+        # Verify session_id is populated
+        assert client.session_id == "test-uuid-123"
+        # Verify pending_status was cleared
+        assert client.pending_status is None
+        # Verify _send_status_patch was called with enqueued status
+        client._send_status_patch.assert_called_once_with(
+            "test-uuid-123", "completed"
+        )
+    finally:
+        urllib.request.urlopen = original_urlopen
+

--- a/packages/server/main.py
+++ b/packages/server/main.py
@@ -240,10 +240,17 @@ async def handle_sdk_event(message: dict) -> None:
                     session.total_tokens += token_delta
                     session.total_cost_usd += cost_delta
 
+            # Implicit session status synchronization from root terminal events (Sub-Issue 5.2)
+            if db_event.event_type == "chain_end" and not db_event.parent_event_id:
+                session.status = "completed"
+                session.ended_at = ts
+            elif db_event.event_type == "chain_error" and not db_event.parent_event_id:
+                session.status = "failed"
+                session.ended_at = ts
+
             await db.commit()
             await db.refresh(session)
             await db.refresh(db_event)
-
             # 5. Broadcast updated event to session UI subscribers
             ui_event = {
                 "event_id": db_event.event_id,

--- a/packages/server/tests/test_server.py
+++ b/packages/server/tests/test_server.py
@@ -282,3 +282,67 @@ def test_set_sqlite_pragma_bypasses_non_sqlite():
         database.engine = original_engine
 
 
+def test_implicit_session_status_synchronization():
+    import uuid
+    import time
+    from fastapi.testclient import TestClient
+
+    session_id = f"status-sync-session-{uuid.uuid4()}"
+    run_id = f"run-root-{uuid.uuid4()}"
+
+    with TestClient(app) as client:
+        # Create session
+        client.post(
+            "/api/sessions",
+            json={
+                "session_id": session_id,
+                "name": "Root status sync test",
+            },
+        )
+
+        # Verify that session is initially "running"
+        res_sess = client.get(f"/api/sessions/{session_id}")
+        assert res_sess.status_code == 200
+        assert res_sess.json()["status"] == "running"
+        assert res_sess.json()["ended_at"] is None
+
+        with client.websocket_connect("/ws?client_type=sdk") as websocket:
+            # Send root chain completed event (parent_event_id is None)
+            websocket.send_json(
+                {
+                    "type": "event",
+                    "session_id": session_id,
+                    "event": {
+                        "event_id": run_id,
+                        "event_type": "chain_end",
+                        "agent_name": "Chain",
+                        "agent_type": "chain",
+                        "status": "completed",
+                        "timestamp": "2026-07-24T12:00:00.000Z",
+                        "payload": {
+                            "chain_type": "Chain",
+                            "inputs": {},
+                            "outputs": {},
+                        },
+                    },
+                }
+            )
+
+            # Wait for websocket ingestion to process and implicitly update session status
+            for _ in range(30):
+                response = client.get(f"/api/sessions/{session_id}")
+                if response.status_code == 200:
+                    data = response.json()
+                    if data.get("status") == "completed":
+                        break
+                time.sleep(0.1)
+
+        # Check that session status has transitioned to "completed" and ended_at is set
+        res_sess = client.get(f"/api/sessions/{session_id}")
+        assert res_sess.status_code == 200
+        sess_data = res_sess.json()
+        assert sess_data["status"] == "completed"
+        assert sess_data["ended_at"] is not None
+
+
+


### PR DESCRIPTION
This Pull Request resolves Issue #24: Session Status Patch Lost due to SDK and Server Desynchronization.

### Changes:
- **REST Patch Retry Queue (Sub-Issue 5.1):** Implemented enqueuing of the final session status patch within `AgentScopeClient` in `packages/sdk/agentscope/client.py`. If a session status patch is sent before `session_id` has been successfully initialized on the server, it is stored in `self.pending_status` and automatically dispatched thread-safely as soon as the session creation request completes.
- **Async Status Synchronization (Sub-Issue 5.2):** Enhanced `packages/server/main.py` to implicitly transition session statuses to `"completed"` or `"failed"` and set `ended_at` when terminal events (`chain_end` or `chain_error`) on the root chain are ingested. This acts as a robust server-side fallback for fast-running pipelines.

### Verification:
- Added a unit test `test_client_pending_status_patch` in `packages/sdk/tests/test_sdk.py` to verify enqueuing and automatic dispatch of enqueued statuses.
- Added an integration test `test_implicit_session_status_synchronization` in `packages/server/tests/test_server.py` to assert that root terminal events trigger implicit session state changes.
- All tests pass cleanly.