### PR TITLE
feat: implement SQL pagination for session events endpoint

### DIFF
--- a/packages/server/routers/events.py
+++ b/packages/server/routers/events.py
@@ -1,25 +1,26 @@
 from typing import Dict, List, Optional
 from fastapi import APIRouter, Depends, HTTPException, Query, status
-from sqlalchemy import select
+from sqlalchemy import select, func
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from database import get_db
 from models import EventModel, SessionModel
-from schemas import EventResponse
+from schemas import EventResponse, PaginatedEventsResponse
 
 # Router prefix matches the session-event hierarchy
 router = APIRouter(prefix="/sessions/{session_id}/events", tags=["events"])
 
 
-@router.get("", response_model=Dict[str, List[EventResponse]])
+@router.get("", response_model=PaginatedEventsResponse)
 async def list_session_events(
     session_id: str,
     event_type: Optional[str] = Query(None, alias="type"),
     agent_name: Optional[str] = Query(None, alias="agent"),
+    page: int = Query(1, ge=1),
     limit: int = Query(100, ge=1, le=1000),
     db: AsyncSession = Depends(get_db),
 ):
-    """Retrieve all logged telemetry events for a session, with optional type and agent filters."""
+    """Retrieve logged telemetry events for a session with optional filters and offset pagination."""
     # First, verify session exists
     sess_stmt = select(SessionModel).where(SessionModel.session_id == session_id)
     sess_res = await db.execute(sess_stmt)
@@ -28,7 +29,19 @@ async def list_session_events(
             status_code=status.HTTP_404_NOT_FOUND, detail="Session not found"
         )
 
-    # Build filtered query
+    # Build count query
+    count_stmt = select(func.count(EventModel.event_id)).where(
+        EventModel.session_id == session_id
+    )
+    if event_type:
+        count_stmt = count_stmt.where(EventModel.event_type == event_type)
+    if agent_name:
+        count_stmt = count_stmt.where(EventModel.agent_name == agent_name)
+
+    count_res = await db.execute(count_stmt)
+    total_count = count_res.scalar() or 0
+
+    # Build paginated query
     stmt = (
         select(EventModel)
         .where(EventModel.session_id == session_id)
@@ -39,11 +52,20 @@ async def list_session_events(
     if agent_name:
         stmt = stmt.where(EventModel.agent_name == agent_name)
 
-    stmt = stmt.limit(limit)
+    offset = (page - 1) * limit
+    stmt = stmt.offset(offset).limit(limit)
     res = await db.execute(stmt)
     events = res.scalars().all()
 
-    return {"events": [EventResponse.model_validate(e) for e in events]}
+    total_pages = (total_count + limit - 1) // limit if total_count > 0 else 1
+
+    return {
+        "events": [EventResponse.model_validate(e) for e in events],
+        "total_count": total_count,
+        "page": page,
+        "limit": limit,
+        "total_pages": max(1, total_pages),
+    }
 
 
 @router.get("/{event_id}", response_model=EventResponse)

--- a/packages/server/schemas.py
+++ b/packages/server/schemas.py
@@ -111,3 +111,12 @@ class StatsResponse(BaseModel):
     error_count: int
     agents: List[AgentStats]
     token_timeline: List[TokenTimelinePoint]
+
+
+class PaginatedEventsResponse(BaseModel):
+    events: List[EventResponse]
+    total_count: int
+    page: int
+    limit: int
+    total_pages: int
+

--- a/packages/server/tests/test_server.py
+++ b/packages/server/tests/test_server.py
@@ -432,5 +432,92 @@ def test_sdk_client_integration(db_engine):
         thread.join(timeout=2.0)
 
 
+def test_list_events_pagination():
+    import uuid
+    from fastapi.testclient import TestClient
+
+    session_id = f"pagination-test-{uuid.uuid4()}"
+    with TestClient(app) as client:
+        # Create session
+        client.post(
+            "/api/sessions",
+            json={
+                "session_id": session_id,
+                "name": "Pagination Test Run",
+            },
+        )
+
+        with client.websocket_connect("/ws?client_type=sdk") as websocket:
+            # Send 5 events
+            for i in range(5):
+                websocket.send_json(
+                    {
+                        "type": "event",
+                        "session_id": session_id,
+                        "event": {
+                            "event_id": f"event-{i}-{uuid.uuid4()}",
+                            "event_type": "chain_start",
+                            "agent_name": f"agent-{i}",
+                            "agent_type": "chain",
+                            "status": "running",
+                            "timestamp": f"2026-08-04T12:00:0{i}.000Z",
+                            "payload": {"index": i},
+                        },
+                    }
+                )
+
+            # Wait for ingestion to complete
+            import time
+
+            for _ in range(30):
+                # Retrieve first page with limit=2
+                res = client.get(
+                    f"/api/sessions/{session_id}/events?page=1&limit=2"
+                )
+                if res.status_code == 200 and res.json()["total_count"] == 5:
+                    break
+                time.sleep(0.1)
+
+        # 1. Verify page 1 of limit 2
+        res = client.get(f"/api/sessions/{session_id}/events?page=1&limit=2")
+        assert res.status_code == 200
+        data = res.json()
+        assert data["total_count"] == 5
+        assert len(data["events"]) == 2
+        assert data["page"] == 1
+        assert data["limit"] == 2
+        assert data["total_pages"] == 3
+        assert data["events"][0]["payload"]["index"] == 0
+        assert data["events"][1]["payload"]["index"] == 1
+
+        # 2. Verify page 2 of limit 2
+        res = client.get(f"/api/sessions/{session_id}/events?page=2&limit=2")
+        assert res.status_code == 200
+        data = res.json()
+        assert len(data["events"]) == 2
+        assert data["page"] == 2
+        assert data["events"][0]["payload"]["index"] == 2
+        assert data["events"][1]["payload"]["index"] == 3
+
+        # 3. Verify page 3 of limit 2 (last page, only 1 event)
+        res = client.get(f"/api/sessions/{session_id}/events?page=3&limit=2")
+        assert res.status_code == 200
+        data = res.json()
+        assert len(data["events"]) == 1
+        assert data["page"] == 3
+        assert data["events"][0]["payload"]["index"] == 4
+
+        # 4. Verify filters with pagination
+        res = client.get(
+            f"/api/sessions/{session_id}/events?page=1&limit=2&agent=agent-2"
+        )
+        assert res.status_code == 200
+        data = res.json()
+        assert data["total_count"] == 1
+        assert len(data["events"]) == 1
+        assert data["total_pages"] == 1
+
+
+
 
 


### PR DESCRIPTION
This Pull Request resolves Issue #30: feat(server): Implement SQL-based Pagination for Session Events Endpoint.

### Changes:
- **Pagination Schema (schemas.py):** Added the `PaginatedEventsResponse` Pydantic model to encapsulate total event count, requested page, limit size, calculated total pages, and the page slice of `EventResponse` models.
- **SQL Offset Pagination Query (events.py):** Updated `/api/sessions/{session_id}/events` to parse `page` and `limit` query parameters, perform an efficient COUNT query to compute totals, and use `offset()` and `limit()` clauses in SQLAlchemy to slice telemetry events.
- **Verification:** Added `test_list_events_pagination` in `packages/server/tests/test_server.py` verifying offset offsets, limits, totals, and combination filtering for session event retrieval.

All 14 tests pass successfully.