### PR TITLE
feat: implement session pruning and data retention policy

### DIFF
--- a/packages/server/main.py
+++ b/packages/server/main.py
@@ -22,11 +22,81 @@ logging.basicConfig(
 )
 
 
+async def prune_old_sessions() -> None:
+    """Prune old sessions based on RETENTION_DAYS and MAX_SESSIONS settings."""
+    retention_days_raw = os.getenv("RETENTION_DAYS")
+    max_sessions_raw = os.getenv("MAX_SESSIONS")
+
+    if not retention_days_raw and not max_sessions_raw:
+        return
+
+    from datetime import datetime, timedelta
+    from sqlalchemy import delete
+
+    async with async_session_maker() as db:
+        try:
+            # 1. Prune by retention days
+            if retention_days_raw:
+                try:
+                    days = int(retention_days_raw)
+                    cutoff = datetime.utcnow() - timedelta(days=days)
+                    stmt = delete(SessionModel).where(SessionModel.started_at < cutoff)
+                    res = await db.execute(stmt)
+                    await db.commit()
+                    deleted_count = res.rowcount
+                    if deleted_count:
+                        logging.info(
+                            f"Pruned {deleted_count} sessions older than {days} days "
+                            f"(cutoff: {cutoff.isoformat()})"
+                        )
+                except ValueError:
+                    logging.warning(f"Invalid RETENTION_DAYS value: {retention_days_raw}")
+
+            # 2. Prune by max session limit
+            if max_sessions_raw:
+                try:
+                    limit = int(max_sessions_raw)
+                    # Count current sessions
+                    cnt_stmt = select(func.count(SessionModel.session_id))
+                    cnt_res = await db.execute(cnt_stmt)
+                    total_sessions = cnt_res.scalar() or 0
+
+                    if total_sessions > limit:
+                        excess = total_sessions - limit
+                        # Retrieve the IDs of the oldest excess sessions
+                        old_stmt = (
+                            select(SessionModel.session_id)
+                            .order_by(SessionModel.started_at.asc())
+                            .limit(excess)
+                        )
+                        old_res = await db.execute(old_stmt)
+                        ids_to_delete = old_res.scalars().all()
+
+                        if ids_to_delete:
+                            del_stmt = delete(SessionModel).where(
+                                SessionModel.session_id.in_(ids_to_delete)
+                            )
+                            await db.execute(del_stmt)
+                            await db.commit()
+                            logging.info(
+                                f"Pruned {len(ids_to_delete)} oldest sessions to enforce "
+                                f"MAX_SESSIONS limit of {limit}."
+                            )
+                except ValueError:
+                    logging.warning(f"Invalid MAX_SESSIONS value: {max_sessions_raw}")
+
+        except Exception as e:
+            logging.error(f"Error during database session pruning: {e}")
+            await db.rollback()
+
+
 @asynccontextmanager
 async def lifespan(app: FastAPI):
     # Initialize DB schema
     async with engine.begin() as conn:
         await conn.run_sync(Base.metadata.create_all)
+    # Prune old sessions on startup
+    await prune_old_sessions()
     yield
     # Teardown connection pool
     await engine.dispose()

--- a/packages/server/tests/test_server.py
+++ b/packages/server/tests/test_server.py
@@ -432,5 +432,107 @@ def test_sdk_client_integration(db_engine):
         thread.join(timeout=2.0)
 
 
+@pytest.mark.asyncio
+async def test_session_retention_pruning(db_session):
+    import os
+    import uuid
+    from datetime import datetime, timedelta
+    from models import SessionModel
+    from main import prune_old_sessions
+    from sqlalchemy import select, delete
+
+    # Clear existing database sessions to ensure isolated counts
+    await db_session.execute(delete(SessionModel))
+    await db_session.commit()
+
+    # Insert 1 old session (10 days ago) and 1 new session (now)
+    old_id = f"old-{uuid.uuid4()}"
+    new_id = f"new-{uuid.uuid4()}"
+
+    old_sess = SessionModel(
+        session_id=old_id,
+        name="Old Session",
+        status="completed",
+        started_at=datetime.utcnow() - timedelta(days=10),
+    )
+    new_sess = SessionModel(
+        session_id=new_id,
+        name="New Session",
+        status="completed",
+        started_at=datetime.utcnow(),
+    )
+
+    db_session.add(old_sess)
+    db_session.add(new_sess)
+    await db_session.commit()
+
+    # Trigger prune with RETENTION_DAYS = 5
+    os.environ["RETENTION_DAYS"] = "5"
+    try:
+        await prune_old_sessions()
+
+        # Verify old session is deleted, new session remains
+        stmt = select(SessionModel).where(
+            SessionModel.session_id.in_([old_id, new_id])
+        )
+        res = await db_session.execute(stmt)
+        remaining = res.scalars().all()
+
+        assert len(remaining) == 1
+        assert remaining[0].session_id == new_id
+    finally:
+        if "RETENTION_DAYS" in os.environ:
+            del os.environ["RETENTION_DAYS"]
+
+
+@pytest.mark.asyncio
+async def test_session_max_limit_pruning(db_session):
+    import os
+    import uuid
+    from datetime import datetime, timedelta
+    from models import SessionModel
+    from main import prune_old_sessions
+    from sqlalchemy import select, delete
+
+    # Clear existing database sessions to ensure isolated counts
+    await db_session.execute(delete(SessionModel))
+    await db_session.commit()
+
+    # Insert 4 sessions with different started_at times
+    session_ids = []
+    for i in range(4):
+        sid = f"limit-{i}-{uuid.uuid4()}"
+        sess = SessionModel(
+            session_id=sid,
+            name=f"Session {i}",
+            status="completed",
+            started_at=datetime.utcnow() - timedelta(minutes=10 - i),
+        )
+        db_session.add(sess)
+        session_ids.append(sid)
+    await db_session.commit()
+
+    # Trigger prune with MAX_SESSIONS = 2
+    os.environ["MAX_SESSIONS"] = "2"
+    try:
+        await prune_old_sessions()
+
+        # Verify only the 2 newest sessions remain (limit-2 and limit-3)
+        stmt = select(SessionModel).where(
+            SessionModel.session_id.in_(session_ids)
+        )
+        res = await db_session.execute(stmt)
+        remaining = res.scalars().all()
+
+        assert len(remaining) == 2
+        remaining_ids = {r.session_id for r in remaining}
+        assert session_ids[2] in remaining_ids
+        assert session_ids[3] in remaining_ids
+    finally:
+        if "MAX_SESSIONS" in os.environ:
+            del os.environ["MAX_SESSIONS"]
+
+
+
 
 


### PR DESCRIPTION
This Pull Request resolves Issue #31: feat(server): Implement Session Pruning & Data Retention policy.

### Changes:
- **Session Pruning Logic (main.py):** Implemented `prune_old_sessions()` which runs on server startup within the FastAPI lifespan handler.
  - Supports `RETENTION_DAYS` configuration to delete sessions older than a specified number of days.
  - Supports `MAX_SESSIONS` configuration to keep only the newest N sessions, deleting the oldest excess sessions.
- **Verification:** Added `test_session_retention_pruning` and `test_session_max_limit_pruning` in `packages/server/tests/test_server.py` verifying retention filters, maximum limit bounds, and database isolation.

All 14 tests pass successfully.