### PR TITLE
chore: standardize UTC timestamp handling and remove conftest prints

### DIFF
--- a/packages/server/main.py
+++ b/packages/server/main.py
@@ -2,7 +2,7 @@ import json
 import logging
 import os
 from contextlib import asynccontextmanager
-from datetime import datetime
+from datetime import datetime, timezone
 from typing import Optional
 from fastapi import FastAPI, Query, WebSocket, WebSocketDisconnect
 from fastapi.middleware.cors import CORSMiddleware
@@ -94,7 +94,7 @@ async def handle_sdk_event(message: dict) -> None:
                     session_id=sess_id,
                     name=f"session_{sess_id[:8]}",
                     status="running",
-                    started_at=datetime.utcnow(),
+                    started_at=datetime.now(timezone.utc),
                 )
                 db.add(session)
                 await db.commit()
@@ -106,7 +106,7 @@ async def handle_sdk_event(message: dict) -> None:
                 ts_str = ts_str.replace("Z", "+00:00")
                 ts = datetime.fromisoformat(ts_str)
             else:
-                ts = datetime.utcnow()
+                ts = datetime.now(timezone.utc)
 
             payload = event_data.get("payload") or {}
 
@@ -259,7 +259,7 @@ async def handle_sdk_event(message: dict) -> None:
                 "event_type": db_event.event_type,
                 "agent_name": db_event.agent_name,
                 "agent_type": db_event.agent_type,
-                "timestamp": db_event.timestamp.isoformat() + "Z",
+                "timestamp": db_event.timestamp.replace(tzinfo=timezone.utc).isoformat(),
                 "latency_ms": db_event.latency_ms,
                 "status": db_event.status,
                 "payload": db_event.payload,

--- a/packages/server/models.py
+++ b/packages/server/models.py
@@ -1,4 +1,4 @@
-from datetime import datetime
+from datetime import datetime, timezone
 from sqlalchemy import Column, DateTime, Float, ForeignKey, Integer, String, JSON
 from sqlalchemy.orm import relationship
 
@@ -13,7 +13,7 @@ class SessionModel(Base):
     session_id = Column(String, primary_key=True)
     name = Column(String, nullable=False)
     status = Column(String, nullable=False)  # "running", "completed", "failed"
-    started_at = Column(DateTime, nullable=False, default=datetime.utcnow)
+    started_at = Column(DateTime, nullable=False, default=lambda: datetime.now(timezone.utc))
     ended_at = Column(DateTime, nullable=True)
     total_tokens = Column(Integer, default=0)
     total_cost_usd = Column(Float, default=0.0)

--- a/packages/server/routers/sessions.py
+++ b/packages/server/routers/sessions.py
@@ -1,5 +1,5 @@
 import uuid
-from datetime import datetime
+from datetime import datetime, timezone
 from typing import Any, Dict, List
 from fastapi import APIRouter, Depends, HTTPException, Query, status
 from sqlalchemy import select, delete, func
@@ -70,7 +70,7 @@ async def create_session(session_in: SessionCreate, db: AsyncSession = Depends(g
         session_id=session_id,
         name=session_in.name,
         status="running",
-        started_at=datetime.utcnow(),
+        started_at=datetime.now(timezone.utc),
         metadata_=session_in.metadata or {},
     )
     db.add(db_session)
@@ -158,7 +158,7 @@ async def update_session(
     if session_update.ended_at is not None:
         db_session.ended_at = session_update.ended_at
     elif session_update.status.value in ["completed", "failed"]:
-        db_session.ended_at = datetime.utcnow()
+        db_session.ended_at = datetime.now(timezone.utc)
 
     # Recalculate session aggregates from events before finishing
     event_stmt = select(EventModel).where(EventModel.session_id == session_id)
@@ -278,7 +278,7 @@ async def get_session_stats(session_id: str, db: AsyncSession = Depends(get_db))
             # Append timeline point
             timeline.append(
                 TokenTimelinePoint(
-                    timestamp=ev.timestamp.isoformat() + "Z",
+                    timestamp=ev.timestamp.replace(tzinfo=timezone.utc).isoformat(),
                     cumulative_tokens=current_cumulative_tokens,
                 )
             )

--- a/packages/server/tests/conftest.py
+++ b/packages/server/tests/conftest.py
@@ -12,10 +12,6 @@ import main
 from database import Base, get_db
 from main import app
 
-print("CONFTEST Base ID:", id(Base))
-print("MODELS Base ID:", id(models.Base))
-print("MODELS registry tables:", list(models.Base.metadata.tables.keys()))
-
 
 # Temporary file database for testing to avoid SQLite connection isolation traps
 TEST_DATABASE_URL = "sqlite+aiosqlite:///./test_temp.db"
@@ -42,8 +38,6 @@ async def db_engine():
     )
     database.async_session_maker = test_session_maker
     main.async_session_maker = test_session_maker
-
-    print("REGISTRY TABLES BEFORE CREATE:", list(Base.metadata.tables.keys()))
     async with engine.begin() as conn:
         await conn.run_sync(Base.metadata.create_all)
     yield engine


### PR DESCRIPTION
This Pull Request resolves Issue #39: chore: remove leftover debug prints and standardize UTC timestamp handling.

### Changes:
- **Removed Debug Prints (conftest.py):** Removed the stdout print statements displaying metadata table registries and SQLAlchemy base registry identifiers that ran during testing.
- **Standardized UTC Handling (main.py, models.py, sessions.py):**
  - Replaced naive `datetime.utcnow()` with timezone-aware `datetime.now(timezone.utc)`.
  - Replaced manual `.isoformat() + "Z"` suffix modifications with native Python timezone offset representations via `.replace(tzinfo=timezone.utc).isoformat()`.

All tests pass successfully.