### PR TITLE
fix(server): lower websockets floor to 16.1.1 for Python 3.10 CI

### DIFF
--- a/packages/server/requirements.txt
+++ b/packages/server/requirements.txt
@@ -2,7 +2,7 @@ fastapi>=0.141.1,<1.0.0
 uvicorn>=0.22.0
 sqlalchemy>=2.0.0
 pydantic>=2.13.4
-websockets>=17.0
+websockets>=16.1.1
 python-dotenv>=1.0.0
 aiosqlite>=0.22.1
 greenlet


### PR DESCRIPTION
## Problem
The `Test FastAPI Server` CI check is failing on `main` during dependency installation:
`ERROR: Could not find a version that satisfies the requirement websockets>=17.0 (from versions: 1.0...16.1.1); ERROR: Ignored the following versions that require a different python version: 17.0 Requires-Python >=3.11; 17.0.1 Requires-Python >=3.11`

## Root cause
Dependabot PR #52 (commit c85c71c) raised the server's `websockets` floor from `>=11.0` to `>=17.0`. However `websockets>=17.0` requires Python 3.11+, while the CI workflow (.github/workflows/ci.yml) runs `setup-python` with `python-version: 3.10`. On Python 3.10 pip cannot resolve the constraint, so the job fails.

## Fix
Lower the floor to `websockets>=16.1.1` (the newest line compatible with Python 3.10). This still allows pip to pick 17.x on newer Pythons, while letting 3.10 resolve to 16.1.1. It also aligns the server with the SDK's existing `websockets>=16.1.1` (packages/sdk/pyproject.toml).

## Verification
- Local run of `packages/server/tests` (Python 3.13, websockets 17.0.1) passes; the only local failures are pre-existing pytest-asyncio ordering flakiness unrelated to this change.
- PR #66 already ran the identical server suite on CI Python 3.10 with `websockets>=16.1.1` and its `Test FastAPI Server` check passed.