### PR TITLE
fix(ci): update changelog generator logic and workflow configuration

### DIFF
--- a/.github/scripts/tests/test_update_changelog.py
+++ b/.github/scripts/tests/test_update_changelog.py
@@ -1,0 +1,78 @@
+import os
+import sys
+import tempfile
+import pytest
+
+# Add parent directory of scripts to sys.path
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+from update_changelog import parse_commit, format_changelog, update_changelog_file
+
+
+def test_parse_commit():
+    c_type, scope, msg = parse_commit("feat(sdk): add support for model pricing")
+    assert c_type == "feat"
+    assert scope == "sdk"
+    assert msg == "add support for model pricing"
+
+    c_type, scope, msg = parse_commit("fix: resolve null reference in session handler")
+    assert c_type == "fix"
+    assert scope is None
+    assert msg == "resolve null reference in session handler"
+
+    c_type, scope, msg = parse_commit("random commit message without conventional format")
+    assert c_type is None
+    assert scope is None
+    assert msg == "random commit message without conventional format"
+
+
+def test_format_changelog():
+    commits = [
+        {"subject": "feat(cli): implement launcher for local and Docker services"},
+        {"subject": "fix(server): resolve next.config.js stray syntax error"},
+        {"subject": "chore: update CHANGELOG.md"},  # Should be filtered out
+        {"subject": "Merge pull request #90 from PxA-Labs/feat/cli-launcher"},  # Should be filtered out
+        {"subject": "feat: add support for changelog generator"},  # Should NOT be filtered out just because it contains 'changelog'
+    ]
+
+    formatted = format_changelog(commits)
+
+    assert "### Added" in formatted
+    assert "### Fixed" in formatted
+    assert "**cli**: Implement launcher for local and Docker services" in formatted
+    assert "**server**: Resolve next.config.js stray syntax error" in formatted
+    assert "Add support for changelog generator" in formatted
+    assert "chore: update CHANGELOG.md" not in formatted
+    assert "Merge pull request" not in formatted
+
+
+def test_update_changelog_file_initial_and_update():
+    with tempfile.TemporaryDirectory() as tmpdir:
+        filepath = os.path.join(tmpdir, "CHANGELOG.md")
+
+        # Initial write
+        initial_content = "### Added\n- **cli**: Implement launcher"
+        res1 = update_changelog_file(initial_content, filepath=filepath)
+        assert res1 is True
+
+        with open(filepath, "r", encoding="utf-8") as f:
+            content1 = f.read()
+
+        assert "## [Unreleased]" in content1
+        assert "Implement launcher" in content1
+
+        # Second write (update section, must NOT duplicate header)
+        updated_content = "### Added\n- **cli**: Implement launcher\n- **server**: Fix memory leak"
+        res2 = update_changelog_file(updated_content, filepath=filepath)
+        assert res2 is True
+
+        with open(filepath, "r", encoding="utf-8") as f:
+            content2 = f.read()
+
+        # Verify only one [Unreleased] header exists
+        assert content2.count("## [Unreleased]") == 1
+        assert "Fix memory leak" in content2
+
+        # Third write with identical content should return False
+        res3 = update_changelog_file(updated_content, filepath=filepath)
+        assert res3 is False

--- a/.github/scripts/update_changelog.py
+++ b/.github/scripts/update_changelog.py
@@ -1,11 +1,12 @@
 #!/usr/bin/env python3
+import os
 import re
 import subprocess
 import sys
 from datetime import datetime, timezone
 
 def run_cmd(args):
-    result = subprocess.run(args, capture_output=True, text=True, check=True)
+    result = subprocess.run(args, capture_output=True, text=True, check=True, encoding="utf-8")
     return result.stdout.strip()
 
 def get_last_changelog_commit():
@@ -13,15 +14,16 @@ def get_last_changelog_commit():
         # Get the hash of the last commit that touched CHANGELOG.md
         commit = run_cmd(["git", "log", "-1", "--format=%H", "--", "CHANGELOG.md"])
         if commit:
-            return commit
-    except subprocess.CalledProcessError:
+            return commit.splitlines()[0]
+    except (subprocess.CalledProcessError, IndexError):
         pass
     
     # Fallback to the first commit of the repository
     try:
         commit = run_cmd(["git", "rev-list", "--max-parents=0", "HEAD"])
-        return commit
-    except subprocess.CalledProcessError:
+        if commit:
+            return commit.splitlines()[0]
+    except (subprocess.CalledProcessError, IndexError):
         print("Error: Could not retrieve git history.", file=sys.stderr)
         sys.exit(1)
 
@@ -46,10 +48,10 @@ def get_commits_since(commit_hash):
             continue
         parts = record.split("\x00")
         if len(parts) >= 2:
-            commit_hash = parts[0]
+            c_hash = parts[0]
             subject = parts[1]
             body = parts[2] if len(parts) > 2 else ""
-            commits.append({"hash": commit_hash, "subject": subject, "body": body})
+            commits.append({"hash": c_hash, "subject": subject, "body": body})
     return commits
 
 def parse_commit(subject):
@@ -83,9 +85,15 @@ def format_changelog(commits):
     # Filter and categorize
     for commit in commits:
         subj = commit["subject"]
-        # Skip changelog update commits to avoid recursion/clutter
-        subj_lower = subj.lower()
-        if "changelog" in subj_lower or "release" in subj_lower or "merge pull request" in subj_lower:
+        subj_lower = subj.lower().strip()
+        
+        # Skip automated changelog commits and merge PR commits to avoid recursion
+        if (
+            subj_lower.startswith("chore: update changelog")
+            or subj_lower == "chore: update changelog.md"
+            or "merge pull request" in subj_lower
+            or "merge branch" in subj_lower
+        ):
             continue
             
         c_type, scope, msg = parse_commit(subj)
@@ -120,39 +128,60 @@ def format_changelog(commits):
         
     return "\n".join(lines).strip()
 
-def update_changelog_file(new_content):
+def update_changelog_file(new_content, filepath="CHANGELOG.md"):
     if not new_content:
         print("No new changes to add to CHANGELOG.md.")
         return False
         
-    with open("CHANGELOG.md", "r") as f:
-        content = f.read()
+    if os.path.exists(filepath):
+        with open(filepath, "r", encoding="utf-8") as f:
+            content = f.read()
+    else:
+        content = "# Changelog\n\nAll notable changes to the **AgentScope** project will be documented in this file.\n\n"
         
-    # Get current date in UTC
     date_str = datetime.now(timezone.utc).strftime("%Y-%m-%d")
     header = f"## [Unreleased] - {date_str}"
+    section = f"{header}\n\n{new_content}"
     
-    section = f"{header}\n\n{new_content}\n\n"
-    
-    # Find the first heading starting with "## "
     lines = content.splitlines()
-    insert_idx = -1
+    
+    unreleased_idx = -1
     for idx, line in enumerate(lines):
-        if line.startswith("## "):
-            insert_idx = idx
+        if line.startswith("## [Unreleased]"):
+            unreleased_idx = idx
             break
             
-    if insert_idx != -1:
-        # Insert before the first version heading
-        new_lines = lines[:insert_idx] + [section.strip()] + [""] + lines[insert_idx:]
+    if unreleased_idx != -1:
+        # Find end of existing [Unreleased] section (next '## ' header or end of file)
+        end_idx = len(lines)
+        for idx in range(unreleased_idx + 1, len(lines)):
+            if lines[idx].startswith("## "):
+                end_idx = idx
+                break
+        new_lines = lines[:unreleased_idx] + section.splitlines() + [""] + lines[end_idx:]
     else:
-        # Append to the end if no version headers exist
-        new_lines = lines + ["", section.strip()]
+        # Insert before first version header starting with "## "
+        first_version_idx = -1
+        for idx, line in enumerate(lines):
+            if line.startswith("## "):
+                first_version_idx = idx
+                break
+                
+        if first_version_idx != -1:
+            new_lines = lines[:first_version_idx] + section.splitlines() + [""] + lines[first_version_idx:]
+        else:
+            new_lines = lines + ["", section]
+            
+    final_content = "\n".join(new_lines).strip() + "\n"
+    
+    if os.path.exists(filepath) and final_content == content:
+        print("CHANGELOG.md is already up to date.")
+        return False
+
+    with open(filepath, "w", encoding="utf-8") as f:
+        f.write(final_content)
         
-    with open("CHANGELOG.md", "w") as f:
-        f.write("\n".join(new_lines) + "\n")
-        
-    print("CHANGELOG.md updated successfully.")
+    print(f"{filepath} updated successfully.")
     return True
 
 def main():
@@ -174,3 +203,4 @@ def main():
 
 if __name__ == "__main__":
     main()
+

--- a/.github/workflows/auto-changelog.yml
+++ b/.github/workflows/auto-changelog.yml
@@ -41,3 +41,8 @@ jobs:
           branch: "automation/update-changelog"
           base: main
           delete-branch: true
+          author: "github-actions[bot] <41898282+github-actions[bot]@users.noreply.github.com>"
+          committer: "github-actions[bot] <41898282+github-actions[bot]@users.noreply.github.com>"
+          add-paths: |
+            CHANGELOG.md
+


### PR DESCRIPTION
## Description
Fixes the issue where `Auto Update Changelog / update-changelog (push)` workflow fails or duplicates `[Unreleased]` sections in `CHANGELOG.md`.

### Key Fixes
1. **Prevent Duplicate Unreleased Section**:
   - `update_changelog_file()` now checks if an `## [Unreleased]` header already exists.
   - If present, it replaces the existing `## [Unreleased]` section in-place instead of inserting duplicate `## [Unreleased]` headers on every run.
   - Returns `False` when `CHANGELOG.md` content is unchanged to avoid empty/redundant commits.
2. **Refine Commit Filtering**:
   - Fixed commit filtering in `format_changelog()` so valid features containing the word "changelog" in their description are not filtered out. Only automated changelog update messages like `chore: update changelog` and merge commits are skipped.
3. **Robust File & Git Handling**:
   - Explicit `encoding="utf-8"` added for reading and writing `CHANGELOG.md`.
   - Handles missing `CHANGELOG.md` with default headers.
   - Truncates git commit output with `.splitlines()[0]` to safely handle multi-line returns.
4. **Workflow Configuration**:
   - Configured `add-paths: | CHANGELOG.md` in `auto-changelog.yml` so only `CHANGELOG.md` changes are committed by `peter-evans/create-pull-request`.
   - Explicitly configured `author` and `committer` parameters.
5. **Unit Tests**:
   - Added unit test suite in `.github/scripts/tests/test_update_changelog.py`.
