### PR TITLE
chore: upgrade CI Node version to 20 for Next.js 16

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -79,10 +79,10 @@ jobs:
     steps:
       - uses: actions/checkout@v7
 
-      - name: Set up Node.js 18
+      - name: Set up Node.js 20
         uses: actions/setup-node@v7
         with:
-          node-version: "18"
+          node-version: "20"
 
       - name: Install UI Dependencies
         run: |


### PR DESCRIPTION
## Summary
Upgrades the Node.js version used in the UI compilation step from 18 to 20.

## Rationale
Next.js v16.3.1 (introduced in Dependabot updates) requires Node.js >= 20.9.0. Keeping CI on Node 18 causes the build step to fail on all dependabot PRs. Upgrading Node to 20 resolves these failures and unblocks library updates.

## Testing
- Verified Next.js UI compiles successfully with Node 20+ locally.
- Checked failed CI workflow annotations pointing to Node version mismatch.

Unblocks #109, #113, #115, #116