### PR TITLE
feat(sdk): optional tiktoken integration for local/fallback token counting

### DIFF
--- a/packages/sdk/agentscope/_pricing.py
+++ b/packages/sdk/agentscope/_pricing.py
@@ -129,3 +129,28 @@ def calculate_cost(
     output_cost = (output_tokens / 1_000_000) * prices["output"]
 
     return input_cost + output_cost
+
+
+def estimate_tokens(
+    text: Optional[str], model_name: Optional[str] = None
+) -> Optional[int]:
+    """Estimate token count for text using tiktoken if available.
+
+    Falls back to character heuristic if tiktoken is not installed.
+    Returns None if text is empty or None.
+    """
+    if not text:
+        return None
+
+    try:
+        import tiktoken
+
+        try:
+            encoding = tiktoken.encoding_for_model(model_name or "gpt-4o")
+        except Exception:
+            encoding = tiktoken.get_encoding("cl100k_base")
+        return len(encoding.encode(text))
+    except ImportError:
+        # Fallback to character-based heuristic (~4 chars per token)
+        return max(1, len(text) // 4)
+

--- a/packages/sdk/agentscope/_pricing.py
+++ b/packages/sdk/agentscope/_pricing.py
@@ -153,4 +153,3 @@ def estimate_tokens(
     except ImportError:
         # Fallback to character-based heuristic (~4 chars per token)
         return max(1, len(text) // 4)
-

--- a/packages/sdk/agentscope/callback.py
+++ b/packages/sdk/agentscope/callback.py
@@ -4,7 +4,7 @@ from datetime import datetime, timezone
 from typing import Any, Dict, List, Optional, Sequence
 from uuid import UUID
 
-from agentscope._pricing import calculate_cost
+from agentscope._pricing import calculate_cost, estimate_tokens
 from agentscope.client import AgentScopeClient
 from agentscope.exceptions import BudgetExceededError
 
@@ -324,6 +324,20 @@ class AgentScopeCallback(AsyncCallbackHandler):
                         if (prompt_tokens is not None and completion_tokens is not None)
                         else None
                     )
+
+            # Fallback to local token estimation if API endpoints return
+            # null or empty token metrics
+            if prompt_tokens is None and prompts:
+                prompt_text = (
+                    "\n".join(prompts) if isinstance(prompts, list) else str(prompts)
+                )
+                prompt_tokens = estimate_tokens(prompt_text, model)
+            if completion_tokens is None and completion:
+                completion_tokens = estimate_tokens(completion, model)
+            if total_tokens is None and (
+                prompt_tokens is not None or completion_tokens is not None
+            ):
+                total_tokens = (prompt_tokens or 0) + (completion_tokens or 0)
 
             # Calculate and accumulate cost
             call_cost = calculate_cost(model, prompt_tokens, completion_tokens)

--- a/packages/sdk/pyproject.toml
+++ b/packages/sdk/pyproject.toml
@@ -25,6 +25,9 @@ agentscope = "agentscope.cli:main"
 langchain = [
     "langchain-core>=1.6.1",
 ]
+tiktoken = [
+    "tiktoken>=0.7.0",
+]
 dev = [
     "pytest>=9.1.1",
     "pytest-asyncio>=1.4.0",

--- a/packages/sdk/tests/test_tiktoken_fallback.py
+++ b/packages/sdk/tests/test_tiktoken_fallback.py
@@ -1,0 +1,19 @@
+﻿from agentscope._pricing import estimate_tokens
+
+
+def test_estimate_tokens_with_text():
+    prompt = "You are a helpful assistant assisting an agent."
+    tokens = estimate_tokens(prompt, "gpt-4o")
+    assert tokens is not None
+    assert tokens > 0
+
+
+def test_estimate_tokens_empty():
+    assert estimate_tokens("") is None
+    assert estimate_tokens(None) is None
+
+
+def test_estimate_tokens_model_fallback():
+    tokens = estimate_tokens("Hello world, this is a test prompt.", "unknown-model-xyz")
+    assert tokens is not None
+    assert tokens >= 1


### PR DESCRIPTION
﻿## Summary
This pull request introduces optional `tiktoken` token counting integration in the SDK to handle local models and providers that do not supply completion usage statistics.

## Problem
When executing local LLMs (e.g. via Ollama, vLLM, or LocalAI) or when proprietary providers omit `usage` metadata in completion responses, prompt and completion token counts default to zero or null. This causes downstream cost calculations and budget limit checks to fail silently.

## Changes
- Added `tiktoken = ["tiktoken>=0.7.0"]` under `[project.optional-dependencies]` in `packages/sdk/pyproject.toml`.
- Implemented `estimate_tokens(text, model_name)` in `packages/sdk/agentscope/_pricing.py` that dynamically imports `tiktoken`, resolves model encodings with fallback to `cl100k_base`, and gracefully falls back to character heuristics if `tiktoken` is not installed.
- Integrated fallback estimation into `AgentScopeCallback.on_llm_end` in `packages/sdk/agentscope/callback.py` whenever API responses omit token usage.
- Added comprehensive unit tests in `packages/sdk/tests/test_tiktoken_fallback.py`.

## Validation
- `python -m pytest packages/sdk/tests/test_tiktoken_fallback.py` - 3 passed
- `python -m pytest packages/sdk/tests/test_pricing_parity.py` - 4 passed
- `python -m ruff check packages/sdk/agentscope/_pricing.py packages/sdk/agentscope/callback.py packages/sdk/tests/test_tiktoken_fallback.py` - All checks passed

Fixes #100
