### PR TITLE
feat(sdk): add specialized trace decorators for custom LLMs and tools

### DIFF
--- a/packages/sdk/agentscope/__init__.py
+++ b/packages/sdk/agentscope/__init__.py
@@ -1,7 +1,16 @@
 # AgentScope SDK public interfaces
 
 from agentscope.callback import AgentScopeCallback
-from agentscope.decorators import trace
+from agentscope.decorators import trace, trace_llm, trace_retriever, trace_tool
 from agentscope.exceptions import AgentScopeError, BudgetExceededError
 
-__all__ = ["AgentScopeCallback", "trace", "AgentScopeError", "BudgetExceededError"]
+__all__ = [
+    "AgentScopeCallback",
+    "trace",
+    "trace_llm",
+    "trace_tool",
+    "trace_retriever",
+    "AgentScopeError",
+    "BudgetExceededError",
+]
+

--- a/packages/sdk/agentscope/__init__.py
+++ b/packages/sdk/agentscope/__init__.py
@@ -13,4 +13,3 @@ __all__ = [
     "AgentScopeError",
     "BudgetExceededError",
 ]
-

--- a/packages/sdk/agentscope/decorators.py
+++ b/packages/sdk/agentscope/decorators.py
@@ -6,6 +6,17 @@ import uuid
 from datetime import datetime, timezone
 from typing import Any, Callable, Dict, Optional
 
+try:
+    from agentscope._pricing import estimate_tokens
+except ImportError:
+
+    def estimate_tokens(
+        text: Optional[str], model_name: Optional[str] = None
+    ) -> Optional[int]:
+        if not text:
+            return None
+        return max(1, len(text) // 4)
+
 from agentscope.client import AgentScopeClient
 
 # ContextVar to track the hierarchy of traces in a thread/async context
@@ -296,3 +307,758 @@ def _make_decorator(
     if inspect.iscoroutinefunction(func):
         return async_wrapper
     return sync_wrapper
+
+
+def trace_llm(
+    arg: Any = None,
+    name: Optional[str] = None,
+    model: Optional[str] = None,
+) -> Callable[..., Any]:
+    """Decorator to instrument custom LLM functions with LLMPayload.
+
+    Usage:
+        @trace_llm(model="gpt-4o")
+        def call_my_model(prompt: str):
+            return "completion text"
+    """
+    if callable(arg):
+        func = arg
+        resolved_name = name or func.__name__
+        return _make_llm_decorator(func, resolved_name, model)
+    else:
+        resolved_name = name or (arg if isinstance(arg, str) else None)
+        return lambda f: _make_llm_decorator(f, resolved_name or f.__name__, model)
+
+
+def _extract_llm_prompt(
+    func: Callable[..., Any], args: tuple, kwargs: dict
+) -> list[str]:
+    try:
+        sig = inspect.signature(func)
+        bound = sig.bind_partial(*args, **kwargs)
+        for param in ("prompt", "prompts", "messages", "query", "input", "text"):
+            if param in bound.arguments:
+                val = bound.arguments[param]
+                if isinstance(val, list):
+                    return [str(item) for item in val]
+                return [str(val)]
+    except Exception:
+        pass
+    if args:
+        return [str(args[0])]
+    if kwargs:
+        return [f"{k}: {v}" for k, v in kwargs.items()]
+    return [""]
+
+
+def _make_llm_decorator(
+    func: Callable[..., Any], name: str, model_override: Optional[str]
+) -> Callable[..., Any]:
+    resolved_model = model_override or "custom-llm"
+
+    @functools.wraps(func)
+    def sync_wrapper(*args: Any, **kwargs: Any) -> Any:
+        client = None
+        try:
+            client = get_global_client()
+        except Exception:
+            pass
+
+        run_id = str(uuid.uuid4())
+        parent_id = current_parent_run_id.get()
+        token = current_parent_run_id.set(run_id)
+        prompts = _extract_llm_prompt(func, args, kwargs)
+
+        if client:
+            try:
+                client.emit(
+                    {
+                        "event_id": run_id,
+                        "session_id": "",
+                        "parent_event_id": parent_id,
+                        "event_type": "llm_start",
+                        "agent_name": name,
+                        "agent_type": "llm",
+                        "timestamp": datetime.now(timezone.utc).isoformat(),
+                        "latency_ms": None,
+                        "status": "running",
+                        "payload": {
+                            "model": resolved_model,
+                            "prompts": prompts,
+                            "completion": None,
+                            "prompt_tokens": None,
+                            "completion_tokens": None,
+                            "total_tokens": None,
+                            "temperature": kwargs.get("temperature"),
+                            "streaming": False,
+                        },
+                    }
+                )
+            except Exception:
+                pass
+
+        start_time = time.perf_counter()
+        try:
+            result = func(*args, **kwargs)
+            latency = int((time.perf_counter() - start_time) * 1000)
+
+            completion = ""
+            if hasattr(result, "content"):
+                completion = str(result.content)
+            elif isinstance(result, str):
+                completion = result
+            elif isinstance(result, dict) and "text" in result:
+                completion = str(result["text"])
+            else:
+                completion = str(result)
+
+            prompt_text = "\n".join(prompts)
+            p_tokens = estimate_tokens(prompt_text, resolved_model)
+            c_tokens = estimate_tokens(completion, resolved_model)
+            t_tokens = (p_tokens or 0) + (c_tokens or 0)
+
+            if client:
+                try:
+                    client.emit(
+                        {
+                            "event_id": run_id,
+                            "session_id": "",
+                            "parent_event_id": parent_id,
+                            "event_type": "llm_end",
+                            "agent_name": name,
+                            "agent_type": "llm",
+                            "timestamp": datetime.now(timezone.utc).isoformat(),
+                            "latency_ms": latency,
+                            "status": "completed",
+                            "payload": {
+                                "model": resolved_model,
+                                "prompts": prompts,
+                                "completion": completion,
+                                "prompt_tokens": p_tokens,
+                                "completion_tokens": c_tokens,
+                                "total_tokens": t_tokens,
+                                "temperature": kwargs.get("temperature"),
+                                "streaming": False,
+                            },
+                        }
+                    )
+                except Exception:
+                    pass
+            return result
+        except Exception as e:
+            latency = int((time.perf_counter() - start_time) * 1000)
+            if client:
+                try:
+                    client.emit(
+                        {
+                            "event_id": run_id,
+                            "session_id": "",
+                            "parent_event_id": parent_id,
+                            "event_type": "llm_error",
+                            "agent_name": name,
+                            "agent_type": "llm",
+                            "timestamp": datetime.now(timezone.utc).isoformat(),
+                            "latency_ms": latency,
+                            "status": "error",
+                            "payload": {
+                                "model": resolved_model,
+                                "prompts": prompts,
+                                "completion": None,
+                                "error": str(e),
+                            },
+                        }
+                    )
+                except Exception:
+                    pass
+            raise e
+        finally:
+            current_parent_run_id.reset(token)
+
+    @functools.wraps(func)
+    async def async_wrapper(*args: Any, **kwargs: Any) -> Any:
+        client = None
+        try:
+            client = get_global_client()
+        except Exception:
+            pass
+
+        run_id = str(uuid.uuid4())
+        parent_id = current_parent_run_id.get()
+        token = current_parent_run_id.set(run_id)
+        prompts = _extract_llm_prompt(func, args, kwargs)
+
+        if client:
+            try:
+                client.emit(
+                    {
+                        "event_id": run_id,
+                        "session_id": "",
+                        "parent_event_id": parent_id,
+                        "event_type": "llm_start",
+                        "agent_name": name,
+                        "agent_type": "llm",
+                        "timestamp": datetime.now(timezone.utc).isoformat(),
+                        "latency_ms": None,
+                        "status": "running",
+                        "payload": {
+                            "model": resolved_model,
+                            "prompts": prompts,
+                            "completion": None,
+                            "prompt_tokens": None,
+                            "completion_tokens": None,
+                            "total_tokens": None,
+                            "temperature": kwargs.get("temperature"),
+                            "streaming": False,
+                        },
+                    }
+                )
+            except Exception:
+                pass
+
+        start_time = time.perf_counter()
+        try:
+            result = await func(*args, **kwargs)
+            latency = int((time.perf_counter() - start_time) * 1000)
+
+            completion = ""
+            if hasattr(result, "content"):
+                completion = str(result.content)
+            elif isinstance(result, str):
+                completion = result
+            elif isinstance(result, dict) and "text" in result:
+                completion = str(result["text"])
+            else:
+                completion = str(result)
+
+            prompt_text = "\n".join(prompts)
+            p_tokens = estimate_tokens(prompt_text, resolved_model)
+            c_tokens = estimate_tokens(completion, resolved_model)
+            t_tokens = (p_tokens or 0) + (c_tokens or 0)
+
+            if client:
+                try:
+                    client.emit(
+                        {
+                            "event_id": run_id,
+                            "session_id": "",
+                            "parent_event_id": parent_id,
+                            "event_type": "llm_end",
+                            "agent_name": name,
+                            "agent_type": "llm",
+                            "timestamp": datetime.now(timezone.utc).isoformat(),
+                            "latency_ms": latency,
+                            "status": "completed",
+                            "payload": {
+                                "model": resolved_model,
+                                "prompts": prompts,
+                                "completion": completion,
+                                "prompt_tokens": p_tokens,
+                                "completion_tokens": c_tokens,
+                                "total_tokens": t_tokens,
+                                "temperature": kwargs.get("temperature"),
+                                "streaming": False,
+                            },
+                        }
+                    )
+                except Exception:
+                    pass
+            return result
+        except Exception as e:
+            latency = int((time.perf_counter() - start_time) * 1000)
+            if client:
+                try:
+                    client.emit(
+                        {
+                            "event_id": run_id,
+                            "session_id": "",
+                            "parent_event_id": parent_id,
+                            "event_type": "llm_error",
+                            "agent_name": name,
+                            "agent_type": "llm",
+                            "timestamp": datetime.now(timezone.utc).isoformat(),
+                            "latency_ms": latency,
+                            "status": "error",
+                            "payload": {
+                                "model": resolved_model,
+                                "prompts": prompts,
+                                "completion": None,
+                                "error": str(e),
+                            },
+                        }
+                    )
+                except Exception:
+                    pass
+            raise e
+        finally:
+            current_parent_run_id.reset(token)
+
+    if inspect.iscoroutinefunction(func):
+        return async_wrapper
+    return sync_wrapper
+
+
+def trace_tool(
+    arg: Any = None,
+    name: Optional[str] = None,
+) -> Callable[..., Any]:
+    """Decorator to instrument custom tool functions with ToolPayload.
+
+    Usage:
+        @trace_tool(name="calculator")
+        def calculate(expression: str):
+            return eval(expression)
+    """
+    if callable(arg):
+        func = arg
+        resolved_name = name or func.__name__
+        return _make_tool_decorator(func, resolved_name)
+    else:
+        resolved_name = name or (arg if isinstance(arg, str) else None)
+        return lambda f: _make_tool_decorator(f, resolved_name or f.__name__)
+
+
+def _extract_tool_input(func: Callable[..., Any], args: tuple, kwargs: dict) -> str:
+    try:
+        sig = inspect.signature(func)
+        bound = sig.bind_partial(*args, **kwargs)
+        for key in ("tool_input", "input", "query", "expression", "text"):
+            if key in bound.arguments:
+                return str(bound.arguments[key])
+        if bound.arguments:
+            return str(dict(bound.arguments))
+    except Exception:
+        pass
+    if args:
+        return str(args[0])
+    if kwargs:
+        return str(kwargs)
+    return ""
+
+
+def _make_tool_decorator(
+    func: Callable[..., Any], name: str
+) -> Callable[..., Any]:
+    @functools.wraps(func)
+    def sync_wrapper(*args: Any, **kwargs: Any) -> Any:
+        client = None
+        try:
+            client = get_global_client()
+        except Exception:
+            pass
+
+        run_id = str(uuid.uuid4())
+        parent_id = current_parent_run_id.get()
+        token = current_parent_run_id.set(run_id)
+        tool_input = _extract_tool_input(func, args, kwargs)
+
+        if client:
+            try:
+                client.emit(
+                    {
+                        "event_id": run_id,
+                        "session_id": "",
+                        "parent_event_id": parent_id,
+                        "event_type": "tool_start",
+                        "agent_name": name,
+                        "agent_type": "tool",
+                        "timestamp": datetime.now(timezone.utc).isoformat(),
+                        "latency_ms": None,
+                        "status": "running",
+                        "payload": {
+                            "tool_name": name,
+                            "tool_input": tool_input,
+                            "tool_output": None,
+                        },
+                    }
+                )
+            except Exception:
+                pass
+
+        start_time = time.perf_counter()
+        try:
+            result = func(*args, **kwargs)
+            latency = int((time.perf_counter() - start_time) * 1000)
+
+            if client:
+                try:
+                    client.emit(
+                        {
+                            "event_id": run_id,
+                            "session_id": "",
+                            "parent_event_id": parent_id,
+                            "event_type": "tool_end",
+                            "agent_name": name,
+                            "agent_type": "tool",
+                            "timestamp": datetime.now(timezone.utc).isoformat(),
+                            "latency_ms": latency,
+                            "status": "completed",
+                            "payload": {
+                                "tool_name": name,
+                                "tool_input": tool_input,
+                                "tool_output": str(result),
+                            },
+                        }
+                    )
+                except Exception:
+                    pass
+            return result
+        except Exception as e:
+            latency = int((time.perf_counter() - start_time) * 1000)
+            if client:
+                try:
+                    client.emit(
+                        {
+                            "event_id": run_id,
+                            "session_id": "",
+                            "parent_event_id": parent_id,
+                            "event_type": "tool_error",
+                            "agent_name": name,
+                            "agent_type": "tool",
+                            "timestamp": datetime.now(timezone.utc).isoformat(),
+                            "latency_ms": latency,
+                            "status": "error",
+                            "payload": {
+                                "tool_name": name,
+                                "tool_input": tool_input,
+                                "error": str(e),
+                            },
+                        }
+                    )
+                except Exception:
+                    pass
+            raise e
+        finally:
+            current_parent_run_id.reset(token)
+
+    @functools.wraps(func)
+    async def async_wrapper(*args: Any, **kwargs: Any) -> Any:
+        client = None
+        try:
+            client = get_global_client()
+        except Exception:
+            pass
+
+        run_id = str(uuid.uuid4())
+        parent_id = current_parent_run_id.get()
+        token = current_parent_run_id.set(run_id)
+        tool_input = _extract_tool_input(func, args, kwargs)
+
+        if client:
+            try:
+                client.emit(
+                    {
+                        "event_id": run_id,
+                        "session_id": "",
+                        "parent_event_id": parent_id,
+                        "event_type": "tool_start",
+                        "agent_name": name,
+                        "agent_type": "tool",
+                        "timestamp": datetime.now(timezone.utc).isoformat(),
+                        "latency_ms": None,
+                        "status": "running",
+                        "payload": {
+                            "tool_name": name,
+                            "tool_input": tool_input,
+                            "tool_output": None,
+                        },
+                    }
+                )
+            except Exception:
+                pass
+
+        start_time = time.perf_counter()
+        try:
+            result = await func(*args, **kwargs)
+            latency = int((time.perf_counter() - start_time) * 1000)
+
+            if client:
+                try:
+                    client.emit(
+                        {
+                            "event_id": run_id,
+                            "session_id": "",
+                            "parent_event_id": parent_id,
+                            "event_type": "tool_end",
+                            "agent_name": name,
+                            "agent_type": "tool",
+                            "timestamp": datetime.now(timezone.utc).isoformat(),
+                            "latency_ms": latency,
+                            "status": "completed",
+                            "payload": {
+                                "tool_name": name,
+                                "tool_input": tool_input,
+                                "tool_output": str(result),
+                            },
+                        }
+                    )
+                except Exception:
+                    pass
+            return result
+        except Exception as e:
+            latency = int((time.perf_counter() - start_time) * 1000)
+            if client:
+                try:
+                    client.emit(
+                        {
+                            "event_id": run_id,
+                            "session_id": "",
+                            "parent_event_id": parent_id,
+                            "event_type": "tool_error",
+                            "agent_name": name,
+                            "agent_type": "tool",
+                            "timestamp": datetime.now(timezone.utc).isoformat(),
+                            "latency_ms": latency,
+                            "status": "error",
+                            "payload": {
+                                "tool_name": name,
+                                "tool_input": tool_input,
+                                "error": str(e),
+                            },
+                        }
+                    )
+                except Exception:
+                    pass
+            raise e
+        finally:
+            current_parent_run_id.reset(token)
+
+    if inspect.iscoroutinefunction(func):
+        return async_wrapper
+    return sync_wrapper
+
+
+def trace_retriever(
+    arg: Any = None,
+    name: Optional[str] = None,
+) -> Callable[..., Any]:
+    """Decorator to instrument retriever search functions.
+
+    Usage:
+        @trace_retriever(name="vector_store")
+        def search(query: str):
+            return ["doc1", "doc2"]
+    """
+    if callable(arg):
+        func = arg
+        resolved_name = name or func.__name__
+        return _make_retriever_decorator(func, resolved_name)
+    else:
+        resolved_name = name or (arg if isinstance(arg, str) else None)
+        return lambda f: _make_retriever_decorator(f, resolved_name or f.__name__)
+
+
+def _extract_retriever_query(
+    func: Callable[..., Any], args: tuple, kwargs: dict
+) -> str:
+    try:
+        sig = inspect.signature(func)
+        bound = sig.bind_partial(*args, **kwargs)
+        for key in ("query", "query_str", "prompt", "text", "search"):
+            if key in bound.arguments:
+                return str(bound.arguments[key])
+    except Exception:
+        pass
+    if args:
+        return str(args[0])
+    if kwargs:
+        return str(kwargs)
+    return ""
+
+
+def _make_retriever_decorator(
+    func: Callable[..., Any], name: str
+) -> Callable[..., Any]:
+    @functools.wraps(func)
+    def sync_wrapper(*args: Any, **kwargs: Any) -> Any:
+        client = None
+        try:
+            client = get_global_client()
+        except Exception:
+            pass
+
+        run_id = str(uuid.uuid4())
+        parent_id = current_parent_run_id.get()
+        token = current_parent_run_id.set(run_id)
+        query = _extract_retriever_query(func, args, kwargs)
+
+        if client:
+            try:
+                client.emit(
+                    {
+                        "event_id": run_id,
+                        "session_id": "",
+                        "parent_event_id": parent_id,
+                        "event_type": "retriever_start",
+                        "agent_name": name,
+                        "agent_type": "retriever",
+                        "timestamp": datetime.now(timezone.utc).isoformat(),
+                        "latency_ms": None,
+                        "status": "running",
+                        "payload": {
+                            "query": query,
+                            "documents": None,
+                        },
+                    }
+                )
+            except Exception:
+                pass
+
+        start_time = time.perf_counter()
+        try:
+            result = func(*args, **kwargs)
+            latency = int((time.perf_counter() - start_time) * 1000)
+
+            docs = (
+                [str(d) for d in result]
+                if isinstance(result, list)
+                else [str(result)]
+            )
+
+            if client:
+                try:
+                    client.emit(
+                        {
+                            "event_id": run_id,
+                            "session_id": "",
+                            "parent_event_id": parent_id,
+                            "event_type": "retriever_end",
+                            "agent_name": name,
+                            "agent_type": "retriever",
+                            "timestamp": datetime.now(timezone.utc).isoformat(),
+                            "latency_ms": latency,
+                            "status": "completed",
+                            "payload": {
+                                "query": query,
+                                "documents": docs,
+                            },
+                        }
+                    )
+                except Exception:
+                    pass
+            return result
+        except Exception as e:
+            latency = int((time.perf_counter() - start_time) * 1000)
+            if client:
+                try:
+                    client.emit(
+                        {
+                            "event_id": run_id,
+                            "session_id": "",
+                            "parent_event_id": parent_id,
+                            "event_type": "retriever_error",
+                            "agent_name": name,
+                            "agent_type": "retriever",
+                            "timestamp": datetime.now(timezone.utc).isoformat(),
+                            "latency_ms": latency,
+                            "status": "error",
+                            "payload": {
+                                "query": query,
+                                "error": str(e),
+                            },
+                        }
+                    )
+                except Exception:
+                    pass
+            raise e
+        finally:
+            current_parent_run_id.reset(token)
+
+    @functools.wraps(func)
+    async def async_wrapper(*args: Any, **kwargs: Any) -> Any:
+        client = None
+        try:
+            client = get_global_client()
+        except Exception:
+            pass
+
+        run_id = str(uuid.uuid4())
+        parent_id = current_parent_run_id.get()
+        token = current_parent_run_id.set(run_id)
+        query = _extract_retriever_query(func, args, kwargs)
+
+        if client:
+            try:
+                client.emit(
+                    {
+                        "event_id": run_id,
+                        "session_id": "",
+                        "parent_event_id": parent_id,
+                        "event_type": "retriever_start",
+                        "agent_name": name,
+                        "agent_type": "retriever",
+                        "timestamp": datetime.now(timezone.utc).isoformat(),
+                        "latency_ms": None,
+                        "status": "running",
+                        "payload": {
+                            "query": query,
+                            "documents": None,
+                        },
+                    }
+                )
+            except Exception:
+                pass
+
+        start_time = time.perf_counter()
+        try:
+            result = await func(*args, **kwargs)
+            latency = int((time.perf_counter() - start_time) * 1000)
+
+            docs = (
+                [str(d) for d in result]
+                if isinstance(result, list)
+                else [str(result)]
+            )
+
+            if client:
+                try:
+                    client.emit(
+                        {
+                            "event_id": run_id,
+                            "session_id": "",
+                            "parent_event_id": parent_id,
+                            "event_type": "retriever_end",
+                            "agent_name": name,
+                            "agent_type": "retriever",
+                            "timestamp": datetime.now(timezone.utc).isoformat(),
+                            "latency_ms": latency,
+                            "status": "completed",
+                            "payload": {
+                                "query": query,
+                                "documents": docs,
+                            },
+                        }
+                    )
+                except Exception:
+                    pass
+            return result
+        except Exception as e:
+            latency = int((time.perf_counter() - start_time) * 1000)
+            if client:
+                try:
+                    client.emit(
+                        {
+                            "event_id": run_id,
+                            "session_id": "",
+                            "parent_event_id": parent_id,
+                            "event_type": "retriever_error",
+                            "agent_name": name,
+                            "agent_type": "retriever",
+                            "timestamp": datetime.now(timezone.utc).isoformat(),
+                            "latency_ms": latency,
+                            "status": "error",
+                            "payload": {
+                                "query": query,
+                                "error": str(e),
+                            },
+                        }
+                    )
+                except Exception:
+                    pass
+            raise e
+        finally:
+            current_parent_run_id.reset(token)
+
+    if inspect.iscoroutinefunction(func):
+        return async_wrapper
+    return sync_wrapper
+

--- a/packages/sdk/agentscope/decorators.py
+++ b/packages/sdk/agentscope/decorators.py
@@ -17,6 +17,7 @@ except ImportError:
             return None
         return max(1, len(text) // 4)
 
+
 from agentscope.client import AgentScopeClient
 
 # ContextVar to track the hierarchy of traces in a thread/async context
@@ -635,9 +636,7 @@ def _extract_tool_input(func: Callable[..., Any], args: tuple, kwargs: dict) -> 
     return ""
 
 
-def _make_tool_decorator(
-    func: Callable[..., Any], name: str
-) -> Callable[..., Any]:
+def _make_tool_decorator(func: Callable[..., Any], name: str) -> Callable[..., Any]:
     @functools.wraps(func)
     def sync_wrapper(*args: Any, **kwargs: Any) -> Any:
         client = None
@@ -909,9 +908,7 @@ def _make_retriever_decorator(
             latency = int((time.perf_counter() - start_time) * 1000)
 
             docs = (
-                [str(d) for d in result]
-                if isinstance(result, list)
-                else [str(result)]
+                [str(d) for d in result] if isinstance(result, list) else [str(result)]
             )
 
             if client:
@@ -1004,9 +1001,7 @@ def _make_retriever_decorator(
             latency = int((time.perf_counter() - start_time) * 1000)
 
             docs = (
-                [str(d) for d in result]
-                if isinstance(result, list)
-                else [str(result)]
+                [str(d) for d in result] if isinstance(result, list) else [str(result)]
             )
 
             if client:
@@ -1061,4 +1056,3 @@ def _make_retriever_decorator(
     if inspect.iscoroutinefunction(func):
         return async_wrapper
     return sync_wrapper
-

--- a/packages/sdk/tests/test_specialized_decorators.py
+++ b/packages/sdk/tests/test_specialized_decorators.py
@@ -1,0 +1,94 @@
+﻿import pytest
+
+from agentscope.decorators import trace_llm, trace_retriever, trace_tool
+
+
+class MockClient:
+    def __init__(self):
+        self.events = []
+
+    def emit(self, event):
+        self.events.append(event)
+
+
+@pytest.fixture(autouse=True)
+def mock_client(monkeypatch):
+    client = MockClient()
+    monkeypatch.setattr("agentscope.decorators.get_global_client", lambda: client)
+    return client
+
+
+def test_trace_llm_sync(mock_client):
+    @trace_llm(model="gpt-4o", name="custom_llm")
+    def my_llm(prompt: str):
+        return "Generated answer for " + prompt
+
+    res = my_llm("Explain physics")
+    assert res == "Generated answer for Explain physics"
+    assert len(mock_client.events) == 2
+
+    start_event = mock_client.events[0]
+    assert start_event["event_type"] == "llm_start"
+    assert start_event["agent_type"] == "llm"
+    assert start_event["payload"]["model"] == "gpt-4o"
+    assert "Explain physics" in start_event["payload"]["prompts"]
+
+    end_event = mock_client.events[1]
+    assert end_event["event_type"] == "llm_end"
+    assert end_event["agent_type"] == "llm"
+    assert end_event["payload"]["completion"] == "Generated answer for Explain physics"
+    assert end_event["payload"]["prompt_tokens"] is not None
+
+
+def test_trace_tool_sync(mock_client):
+    @trace_tool(name="calculator")
+    def calc(expression: str):
+        return 42
+
+    res = calc("6 * 7")
+    assert res == 42
+    assert len(mock_client.events) == 2
+
+    start_event = mock_client.events[0]
+    assert start_event["event_type"] == "tool_start"
+    assert start_event["agent_type"] == "tool"
+    assert start_event["payload"]["tool_name"] == "calculator"
+    assert start_event["payload"]["tool_input"] == "6 * 7"
+
+    end_event = mock_client.events[1]
+    assert end_event["event_type"] == "tool_end"
+    assert end_event["payload"]["tool_output"] == "42"
+
+
+def test_trace_retriever_sync(mock_client):
+    @trace_retriever(name="kb_search")
+    def retrieve(query: str):
+        return ["doc_alpha", "doc_beta"]
+
+    res = retrieve("quantum")
+    assert res == ["doc_alpha", "doc_beta"]
+    assert len(mock_client.events) == 2
+
+    start_event = mock_client.events[0]
+    assert start_event["event_type"] == "retriever_start"
+    assert start_event["agent_type"] == "retriever"
+    assert start_event["payload"]["query"] == "quantum"
+
+    end_event = mock_client.events[1]
+    assert end_event["event_type"] == "retriever_end"
+    assert end_event["payload"]["documents"] == ["doc_alpha", "doc_beta"]
+
+
+def test_trace_tool_error(mock_client):
+    @trace_tool(name="failing_tool")
+    def fail_tool():
+        raise ValueError("Tool failure")
+
+    with pytest.raises(ValueError, match="Tool failure"):
+        fail_tool()
+
+    assert len(mock_client.events) == 2
+    err_event = mock_client.events[1]
+    assert err_event["event_type"] == "tool_error"
+    assert err_event["status"] == "error"
+    assert "Tool failure" in err_event["payload"]["error"]


### PR DESCRIPTION
﻿## Summary
This pull request introduces semantic trace decorators (`@trace_llm`, `@trace_tool`, and `@trace_retriever`) to enable fine-grained, typed telemetry for custom models, tools, and retrieval pipelines outside of LangChain.

## Problem
The previous `@trace` decorator was generic and only emitted `ChainNode` events with raw string arguments. Non-LangChain developers had no clean way to instrument custom LLMs, vector database lookups, and specialized tool functions to map their parameters and outputs into structured `LLMPayload`, `ToolPayload`, and `RetrieverPayload` types on the server dashboard.

## Changes
- Implemented `@trace_llm` in `packages/sdk/agentscope/decorators.py` to capture prompts, model IDs, completions, and token estimates, emitting `llm_start`, `llm_end`, and `llm_error`.
- Implemented `@trace_tool` in `packages/sdk/agentscope/decorators.py` to capture tool inputs and outputs, emitting `tool_start`, `tool_end`, and `tool_error`.
- Implemented `@trace_retriever` in `packages/sdk/agentscope/decorators.py` to capture queries and returned documents, emitting `retriever_start`, `retriever_end`, and `retriever_error`.
- Added signature and argument binding via `inspect.signature` for automatic payload population.
- Supported both synchronous and asynchronous functions across all decorators.
- Exported new decorators in `packages/sdk/agentscope/__init__.py`.
- Added unit tests in `packages/sdk/tests/test_specialized_decorators.py`.

## Validation
- `python -m pytest packages/sdk/tests/test_specialized_decorators.py` - 4 passed
- `python -m ruff check packages/sdk/agentscope/decorators.py packages/sdk/agentscope/__init__.py packages/sdk/tests/test_specialized_decorators.py` - All checks passed

Fixes #99
