### PR TITLE
feat(server): wrap Mem0 operations in async threads and add missing APIs

### DIFF
--- a/packages/server/mem0_integration.py
+++ b/packages/server/mem0_integration.py
@@ -1,17 +1,20 @@
 import asyncio
 import logging
 import os
-from typing import Optional
+from typing import Any, Optional
 
-from mem0 import MemoryClient
+try:
+    from mem0 import MemoryClient
+except ImportError:
+    MemoryClient = None  # type: ignore
 
 logger = logging.getLogger(__name__)
 
 # Initialize client
 MEM0_API_KEY = os.getenv("MEM0_API_KEY")
-client: Optional[MemoryClient] = None
+client: Optional[Any] = None
 
-if MEM0_API_KEY:
+if MEM0_API_KEY and MemoryClient:
     try:
         client = MemoryClient(api_key=MEM0_API_KEY)
         logger.info("Mem0 client initialized successfully.")
@@ -19,12 +22,12 @@ if MEM0_API_KEY:
         logger.error(f"Failed to initialize Mem0 client: {e}")
 else:
     logger.warning(
-        "MEM0_API_KEY is not configured in environment. "
+        "MEM0_API_KEY is not configured or mem0 is not installed. "
         "Mem0 memory integration is disabled."
     )
 
 
-def get_mem0_client() -> Optional[MemoryClient]:
+def get_mem0_client() -> Optional[Any]:
     return client
 
 
@@ -51,3 +54,69 @@ async def add_memory_async(
             logger.error(f"Failed to add memory to Mem0: {e}")
 
     asyncio.create_task(asyncio.to_thread(_add))
+
+
+async def get_all_memories_async(session_id: str) -> Any:
+    """Retrieve all memories for a session asynchronously."""
+    if not client:
+        return []
+    return await asyncio.to_thread(client.get_all, filters={"user_id": session_id})
+
+
+async def add_custom_memory_async(
+    text: str, session_id: str, metadata: Optional[dict] = None
+) -> Any:
+    """Add a custom memory asynchronously."""
+    if not client:
+        return None
+    return await asyncio.to_thread(
+        client.add, text, user_id=session_id, metadata=metadata or {}
+    )
+
+
+async def search_memories_async(query: str, session_id: str) -> Any:
+    """Search memories asynchronously."""
+    if not client:
+        return []
+    return await asyncio.to_thread(
+        client.search, query, filters={"user_id": session_id}
+    )
+
+
+async def update_memory_async(memory_id: str, text: str) -> Any:
+    """Update a specific memory asynchronously."""
+    if not client:
+        return None
+    return await asyncio.to_thread(client.update, memory_id, text)
+
+
+async def delete_memory_async(memory_id: str) -> Any:
+    """Delete a specific memory asynchronously."""
+    if not client:
+        return None
+    return await asyncio.to_thread(client.delete, memory_id)
+
+
+async def delete_all_session_memories_async(session_id: str) -> Any:
+    """Delete all memories for a session asynchronously."""
+    if not client:
+        return None
+    if hasattr(client, "delete_all"):
+        return await asyncio.to_thread(client.delete_all, user_id=session_id)
+
+    # Fallback deletion if client doesn't support delete_all directly
+    memories = await get_all_memories_async(session_id)
+    items = []
+    if isinstance(memories, list):
+        items = memories
+    elif isinstance(memories, dict) and "results" in memories:
+        items = memories["results"]
+
+    deleted_count = 0
+    for m in items:
+        m_id = m.get("id") if isinstance(m, dict) else getattr(m, "id", None)
+        if m_id:
+            await delete_memory_async(m_id)
+            deleted_count += 1
+    return {"deleted": deleted_count}
+

--- a/packages/server/mem0_integration.py
+++ b/packages/server/mem0_integration.py
@@ -5,7 +5,7 @@ from typing import Any, Optional
 
 try:
     from mem0 import MemoryClient
-except ImportError:
+except (ImportError, Exception):
     MemoryClient = None  # type: ignore
 
 logger = logging.getLogger(__name__)
@@ -35,7 +35,8 @@ async def add_memory_async(
     text: str, session_id: str, agent_name: Optional[str] = None
 ) -> None:
     """Send memory to Mem0 without blocking server request ingestion."""
-    if not client:
+    c = get_mem0_client()
+    if not c:
         logger.debug("Mem0 client not configured, skipping memory addition.")
         return
 
@@ -48,7 +49,7 @@ async def add_memory_async(
             logger.info(
                 f"Extracting memory for session {session_id} from text: {text[:60]}..."
             )
-            res = client.add(text, user_id=session_id, metadata=metadata)
+            res = c.add(text, user_id=session_id, metadata=metadata)
             logger.info(f"Mem0 add response: {res}")
         except Exception as e:
             logger.error(f"Failed to add memory to Mem0: {e}")
@@ -58,51 +59,55 @@ async def add_memory_async(
 
 async def get_all_memories_async(session_id: str) -> Any:
     """Retrieve all memories for a session asynchronously."""
-    if not client:
+    c = get_mem0_client()
+    if not c:
         return []
-    return await asyncio.to_thread(client.get_all, filters={"user_id": session_id})
+    return await asyncio.to_thread(c.get_all, filters={"user_id": session_id})
 
 
 async def add_custom_memory_async(
     text: str, session_id: str, metadata: Optional[dict] = None
 ) -> Any:
     """Add a custom memory asynchronously."""
-    if not client:
+    c = get_mem0_client()
+    if not c:
         return None
     return await asyncio.to_thread(
-        client.add, text, user_id=session_id, metadata=metadata or {}
+        c.add, text, user_id=session_id, metadata=metadata or {}
     )
 
 
 async def search_memories_async(query: str, session_id: str) -> Any:
     """Search memories asynchronously."""
-    if not client:
+    c = get_mem0_client()
+    if not c:
         return []
-    return await asyncio.to_thread(
-        client.search, query, filters={"user_id": session_id}
-    )
+    return await asyncio.to_thread(c.search, query, filters={"user_id": session_id})
 
 
 async def update_memory_async(memory_id: str, text: str) -> Any:
     """Update a specific memory asynchronously."""
-    if not client:
+    c = get_mem0_client()
+    if not c:
         return None
-    return await asyncio.to_thread(client.update, memory_id, text)
+    return await asyncio.to_thread(c.update, memory_id, text)
 
 
 async def delete_memory_async(memory_id: str) -> Any:
     """Delete a specific memory asynchronously."""
-    if not client:
+    c = get_mem0_client()
+    if not c:
         return None
-    return await asyncio.to_thread(client.delete, memory_id)
+    return await asyncio.to_thread(c.delete, memory_id)
 
 
 async def delete_all_session_memories_async(session_id: str) -> Any:
     """Delete all memories for a session asynchronously."""
-    if not client:
+    c = get_mem0_client()
+    if not c:
         return None
-    if hasattr(client, "delete_all"):
-        return await asyncio.to_thread(client.delete_all, user_id=session_id)
+    if hasattr(c, "delete_all"):
+        return await asyncio.to_thread(c.delete_all, user_id=session_id)
 
     # Fallback deletion if client doesn't support delete_all directly
     memories = await get_all_memories_async(session_id)
@@ -119,4 +124,3 @@ async def delete_all_session_memories_async(session_id: str) -> Any:
             await delete_memory_async(m_id)
             deleted_count += 1
     return {"deleted": deleted_count}
-

--- a/packages/server/routers/memories.py
+++ b/packages/server/routers/memories.py
@@ -1,7 +1,15 @@
 from typing import Any, Dict, Optional
 
 from fastapi import APIRouter, HTTPException, status
-from mem0_integration import get_mem0_client
+from mem0_integration import (
+    add_custom_memory_async,
+    delete_all_session_memories_async,
+    delete_memory_async,
+    get_all_memories_async,
+    get_mem0_client,
+    search_memories_async,
+    update_memory_async,
+)
 from pydantic import BaseModel
 
 router = APIRouter(prefix="/sessions/{session_id}/memories", tags=["memories"])
@@ -10,6 +18,10 @@ router = APIRouter(prefix="/sessions/{session_id}/memories", tags=["memories"])
 class MemoryCreateRequest(BaseModel):
     text: str
     metadata: Optional[Dict[str, Any]] = None
+
+
+class MemoryUpdateRequest(BaseModel):
+    text: str
 
 
 class MemorySearchRequest(BaseModel):
@@ -31,11 +43,10 @@ def verify_mem0_client():
 
 @router.get("")
 async def list_session_memories(session_id: str):
-    """Retrieve all memories associated with this session."""
-    client = verify_mem0_client()
+    """Retrieve all memories associated with this session asynchronously."""
+    verify_mem0_client()
     try:
-        # Use filters to retrieve user-specific memories for this session
-        res = client.get_all(filters={"user_id": session_id})
+        res = await get_all_memories_async(session_id)
         return res
     except Exception as e:
         raise HTTPException(
@@ -46,11 +57,13 @@ async def list_session_memories(session_id: str):
 
 @router.post("")
 async def add_session_memory(session_id: str, payload: MemoryCreateRequest):
-    """Manually add a memory to this session."""
-    client = verify_mem0_client()
+    """Manually add a memory to this session asynchronously."""
+    verify_mem0_client()
     try:
         metadata = payload.metadata or {}
-        res = client.add(payload.text, user_id=session_id, metadata=metadata)
+        res = await add_custom_memory_async(
+            payload.text, session_id=session_id, metadata=metadata
+        )
         return res
     except Exception as e:
         raise HTTPException(
@@ -61,10 +74,10 @@ async def add_session_memory(session_id: str, payload: MemoryCreateRequest):
 
 @router.post("/search")
 async def search_session_memories(session_id: str, payload: MemorySearchRequest):
-    """Search memories associated with this session using vector similarity search."""
-    client = verify_mem0_client()
+    """Search memories associated with this session using vector search."""
+    verify_mem0_client()
     try:
-        res = client.search(payload.query, filters={"user_id": session_id})
+        res = await search_memories_async(payload.query, session_id=session_id)
         return res
     except Exception as e:
         raise HTTPException(
@@ -73,15 +86,46 @@ async def search_session_memories(session_id: str, payload: MemorySearchRequest)
         )
 
 
+@router.put("/{memory_id}")
+async def update_session_memory(
+    session_id: str, memory_id: str, payload: MemoryUpdateRequest
+):
+    """Update an existing memory text by its ID."""
+    verify_mem0_client()
+    try:
+        res = await update_memory_async(memory_id, payload.text)
+        return res
+    except Exception as e:
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail=f"Failed to update memory in Mem0: {e}",
+        )
+
+
 @router.delete("/{memory_id}")
 async def delete_session_memory(session_id: str, memory_id: str):
     """Delete a specific memory by its ID."""
-    client = verify_mem0_client()
+    verify_mem0_client()
     try:
-        res = client.delete(memory_id)
+        res = await delete_memory_async(memory_id)
         return res
     except Exception as e:
         raise HTTPException(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
             detail=f"Failed to delete memory from Mem0: {e}",
         )
+
+
+@router.delete("")
+async def delete_all_session_memories(session_id: str):
+    """Delete all memories associated with this session."""
+    verify_mem0_client()
+    try:
+        res = await delete_all_session_memories_async(session_id)
+        return res
+    except Exception as e:
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail=f"Failed to bulk delete session memories from Mem0: {e}",
+        )
+

--- a/packages/server/routers/memories.py
+++ b/packages/server/routers/memories.py
@@ -128,4 +128,3 @@ async def delete_all_session_memories(session_id: str):
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
             detail=f"Failed to bulk delete session memories from Mem0: {e}",
         )
-

--- a/packages/server/tests/test_memories.py
+++ b/packages/server/tests/test_memories.py
@@ -80,3 +80,31 @@ async def test_memories_api(mock_mem0_client):
         data = res.json()
         assert data["message"] == "Deleted"
         mock_mem0_client.delete.assert_called_once_with("mem-1")
+
+    # 5. Test update memory
+    mock_mem0_client.update.return_value = {"message": "Updated"}
+    async with AsyncClient(
+        transport=ASGITransport(app=app), base_url="http://test"
+    ) as ac:
+        res = await ac.put(
+            f"/api/sessions/{session_id}/memories/mem-1",
+            json={"text": "Updated memory content"},
+        )
+        assert res.status_code == 200
+        data = res.json()
+        assert data["message"] == "Updated"
+        mock_mem0_client.update.assert_called_once_with(
+            "mem-1", "Updated memory content"
+        )
+
+    # 6. Test bulk delete session memories
+    mock_mem0_client.delete_all.return_value = {"message": "All deleted"}
+    async with AsyncClient(
+        transport=ASGITransport(app=app), base_url="http://test"
+    ) as ac:
+        res = await ac.delete(f"/api/sessions/{session_id}/memories")
+        assert res.status_code == 200
+        data = res.json()
+        assert data["message"] == "All deleted"
+        mock_mem0_client.delete_all.assert_called_once_with(user_id=session_id)
+

--- a/packages/server/tests/test_memories.py
+++ b/packages/server/tests/test_memories.py
@@ -7,9 +7,11 @@ from main import app
 
 @pytest.fixture
 def mock_mem0_client():
-    with patch("routers.memories.get_mem0_client") as mock_get:
-        mock_client = MagicMock()
-        mock_get.return_value = mock_client
+    mock_client = MagicMock()
+    with (
+        patch("routers.memories.get_mem0_client", return_value=mock_client),
+        patch("mem0_integration.get_mem0_client", return_value=mock_client),
+    ):
         yield mock_client
 
 
@@ -107,4 +109,3 @@ async def test_memories_api(mock_mem0_client):
         data = res.json()
         assert data["message"] == "All deleted"
         mock_mem0_client.delete_all.assert_called_once_with(user_id=session_id)
-


### PR DESCRIPTION
﻿## Summary
This pull request wraps Mem0 operations (retrieval, search, update, deletion) in background worker threads using `asyncio.to_thread` to prevent blocking the FastAPI asynchronous event loop, and introduces missing memory update (`PUT`) and session bulk-delete (`DELETE`) endpoints.

## Problem
While adding memories was handled asynchronously via background task, searching memories, listing memories, and deleting memories were executed synchronously in FastAPI endpoint handlers. Under concurrent multi-agent tracing load, blocking synchronous Mem0 network calls degraded server throughput. Furthermore, developers could neither edit memories nor wipe all session memories in a single call.

## Changes
- Wrapped `client.get_all`, `client.search`, `client.delete`, `client.update`, and bulk delete in non-blocking `asyncio.to_thread` helpers within `packages/server/mem0_integration.py`.
- Added graceful `try...except ImportError` fallback for `mem0` imports so environments without Mem0 remain completely stable.
- Added `PUT /sessions/{session_id}/memories/{memory_id}` endpoint to update existing memory text.
- Added `DELETE /sessions/{session_id}/memories` endpoint to wipe all memories associated with a session.
- Updated `packages/server/tests/test_memories.py` to test both memory update and session bulk deletion workflows.

## Validation
- `python -m ruff check packages/server/mem0_integration.py packages/server/routers/memories.py packages/server/tests/test_memories.py` - All checks passed
- All existing endpoints and newly exposed endpoints verified with mock client tests.

Fixes #120
