### PR TITLE
feat(server): retention policies and database auto-vacuum

### DIFF
--- a/packages/server/database.py
+++ b/packages/server/database.py
@@ -27,8 +27,18 @@ def set_sqlite_pragma(dbapi_connection, connection_record):
         cursor.execute("PRAGMA journal_mode=WAL;")
         cursor.execute("PRAGMA foreign_keys=ON;")
         cursor.execute("PRAGMA busy_timeout=5000;")
+        cursor.execute("PRAGMA auto_vacuum = FULL;")
     finally:
         cursor.close()
+
+
+async def vacuum_database() -> None:
+    """Run VACUUM on SQLite database to reclaim free space and defragment."""
+    if engine.dialect.name == "sqlite":
+        from sqlalchemy import text
+
+        async with engine.begin() as conn:
+            await conn.execute(text("VACUUM;"))
 
 
 # Async session factory

--- a/packages/server/main.py
+++ b/packages/server/main.py
@@ -1,3 +1,4 @@
+import asyncio
 import json
 import logging
 import os
@@ -10,6 +11,7 @@ from fastapi import FastAPI, Query, WebSocket, WebSocketDisconnect
 from fastapi.middleware.cors import CORSMiddleware
 from models import EventModel, SessionModel
 from pricing import calculate_cost as _calculate_llm_cost
+from retention import prune_old_sessions
 from routers import events, memories, sessions
 from sqlalchemy import func, select
 from sqlalchemy.exc import IntegrityError
@@ -22,77 +24,22 @@ logging.basicConfig(
 )
 
 
-async def prune_old_sessions() -> None:
-    """Prune old sessions based on RETENTION_DAYS and MAX_SESSIONS settings."""
-    retention_days_raw = os.getenv("RETENTION_DAYS")
-    max_sessions_raw = os.getenv("MAX_SESSIONS")
+async def _periodic_prune() -> None:
+    """Periodically execute database session pruning."""
+    interval_raw = os.getenv("AGENTSCOPE_PRUNE_INTERVAL_SECONDS", "3600")
+    try:
+        interval = int(interval_raw)
+    except ValueError:
+        interval = 3600
 
-    if not retention_days_raw and not max_sessions_raw:
-        return
-
-    from datetime import datetime, timedelta, timezone
-
-    from sqlalchemy import delete
-
-    async with async_session_maker() as db:
+    while True:
         try:
-            # 1. Prune by retention days
-            if retention_days_raw:
-                try:
-                    days = int(retention_days_raw)
-                    cutoff = datetime.now(timezone.utc).replace(
-                        tzinfo=None
-                    ) - timedelta(days=days)
-                    stmt = delete(SessionModel).where(SessionModel.started_at < cutoff)
-                    res = await db.execute(stmt)
-                    await db.commit()
-                    deleted_count = res.rowcount
-                    if deleted_count:
-                        logging.info(
-                            f"Pruned {deleted_count} sessions older than {days} days "
-                            f"(cutoff: {cutoff.isoformat()})"
-                        )
-                except ValueError:
-                    logging.warning(
-                        f"Invalid RETENTION_DAYS value: {retention_days_raw}"
-                    )
-
-            # 2. Prune by max session limit
-            if max_sessions_raw:
-                try:
-                    limit = int(max_sessions_raw)
-                    # Count current sessions
-                    cnt_stmt = select(func.count(SessionModel.session_id))
-                    cnt_res = await db.execute(cnt_stmt)
-                    total_sessions = cnt_res.scalar() or 0
-
-                    if total_sessions > limit:
-                        excess = total_sessions - limit
-                        # Retrieve the IDs of the oldest excess sessions
-                        old_stmt = (
-                            select(SessionModel.session_id)
-                            .order_by(SessionModel.started_at.asc())
-                            .limit(excess)
-                        )
-                        old_res = await db.execute(old_stmt)
-                        ids_to_delete = old_res.scalars().all()
-
-                        if ids_to_delete:
-                            del_stmt = delete(SessionModel).where(
-                                SessionModel.session_id.in_(ids_to_delete)
-                            )
-                            await db.execute(del_stmt)
-                            await db.commit()
-                            logging.info(
-                                f"Pruned {len(ids_to_delete)} oldest sessions "
-                                f"to enforce MAX_SESSIONS limit of {limit}."
-                            )
-                except ValueError:
-                    logging.warning(f"Invalid MAX_SESSIONS value: {max_sessions_raw}")
-
+            await asyncio.sleep(interval)
+            await prune_old_sessions()
+        except asyncio.CancelledError:
+            break
         except Exception as e:
-            logging.error(f"Error during database session pruning: {e}")
-            await db.rollback()
+            logging.error(f"Periodic pruning encountered error: {e}")
 
 
 @asynccontextmanager
@@ -102,9 +49,18 @@ async def lifespan(app: FastAPI):
         await conn.run_sync(Base.metadata.create_all)
     # Prune old sessions on startup
     await prune_old_sessions()
-    yield
-    # Teardown connection pool
-    await engine.dispose()
+    # Periodic pruning worker
+    prune_task = asyncio.create_task(_periodic_prune())
+    try:
+        yield
+    finally:
+        prune_task.cancel()
+        try:
+            await prune_task
+        except asyncio.CancelledError:
+            pass
+        # Teardown connection pool
+        await engine.dispose()
 
 
 app = FastAPI(

--- a/packages/server/retention.py
+++ b/packages/server/retention.py
@@ -1,0 +1,100 @@
+import logging
+import os
+from datetime import datetime, timedelta, timezone
+from typing import Optional
+
+from database import async_session_maker, vacuum_database
+from models import SessionModel
+from sqlalchemy import delete, func, select
+
+logger = logging.getLogger(__name__)
+
+
+async def prune_old_sessions(
+    retention_days: Optional[int] = None,
+    max_sessions: Optional[int] = None,
+    vacuum: bool = True,
+) -> int:
+    """Prune old sessions based on retention policies and run SQLite VACUUM."""
+    retention_days_raw = (
+        str(retention_days)
+        if retention_days is not None
+        else (os.getenv("AGENTSCOPE_RETENTION_DAYS") or os.getenv("RETENTION_DAYS"))
+    )
+    max_sessions_raw = (
+        str(max_sessions)
+        if max_sessions is not None
+        else (os.getenv("AGENTSCOPE_MAX_SESSIONS") or os.getenv("MAX_SESSIONS"))
+    )
+
+    if not retention_days_raw and not max_sessions_raw:
+        return 0
+
+    total_pruned = 0
+    async with async_session_maker() as db:
+        try:
+            # 1. Prune by retention days
+            if retention_days_raw:
+                try:
+                    days = int(retention_days_raw)
+                    cutoff = datetime.now(timezone.utc).replace(
+                        tzinfo=None
+                    ) - timedelta(days=days)
+                    stmt = delete(SessionModel).where(
+                        SessionModel.started_at < cutoff
+                    )
+                    res = await db.execute(stmt)
+                    await db.commit()
+                    deleted_count = res.rowcount or 0
+                    total_pruned += deleted_count
+                    if deleted_count:
+                        logger.info(
+                            f"Pruned {deleted_count} sessions older than "
+                            f"{days} days (cutoff: {cutoff.isoformat()})"
+                        )
+                except ValueError:
+                    logger.warning(
+                        f"Invalid retention days value: {retention_days_raw}"
+                    )
+
+            # 2. Prune by max session limit
+            if max_sessions_raw:
+                try:
+                    limit = int(max_sessions_raw)
+                    cnt_stmt = select(func.count(SessionModel.session_id))
+                    cnt_res = await db.execute(cnt_stmt)
+                    total_sessions = cnt_res.scalar() or 0
+
+                    if total_sessions > limit:
+                        excess = total_sessions - limit
+                        old_stmt = (
+                            select(SessionModel.session_id)
+                            .order_by(SessionModel.started_at.asc())
+                            .limit(excess)
+                        )
+                        old_res = await db.execute(old_stmt)
+                        ids_to_delete = old_res.scalars().all()
+
+                        if ids_to_delete:
+                            del_stmt = delete(SessionModel).where(
+                                SessionModel.session_id.in_(ids_to_delete)
+                            )
+                            await db.execute(del_stmt)
+                            await db.commit()
+                            total_pruned += len(ids_to_delete)
+                            logger.info(
+                                f"Pruned {len(ids_to_delete)} oldest sessions "
+                                f"to enforce max sessions limit of {limit}."
+                            )
+                except ValueError:
+                    logger.warning(
+                        f"Invalid max sessions value: {max_sessions_raw}"
+                    )
+
+            if total_pruned > 0 and vacuum:
+                await vacuum_database()
+        except Exception as e:
+            logger.error(f"Error during database session pruning: {e}")
+            await db.rollback()
+
+    return total_pruned

--- a/packages/server/retention.py
+++ b/packages/server/retention.py
@@ -3,7 +3,7 @@ import os
 from datetime import datetime, timedelta, timezone
 from typing import Optional
 
-from database import async_session_maker, vacuum_database
+import database
 from models import SessionModel
 from sqlalchemy import delete, func, select
 
@@ -14,6 +14,7 @@ async def prune_old_sessions(
     retention_days: Optional[int] = None,
     max_sessions: Optional[int] = None,
     vacuum: bool = True,
+    session_maker=None,
 ) -> int:
     """Prune old sessions based on retention policies and run SQLite VACUUM."""
     retention_days_raw = (
@@ -31,7 +32,8 @@ async def prune_old_sessions(
         return 0
 
     total_pruned = 0
-    async with async_session_maker() as db:
+    maker = session_maker or database.async_session_maker
+    async with maker() as db:
         try:
             # 1. Prune by retention days
             if retention_days_raw:
@@ -40,9 +42,7 @@ async def prune_old_sessions(
                     cutoff = datetime.now(timezone.utc).replace(
                         tzinfo=None
                     ) - timedelta(days=days)
-                    stmt = delete(SessionModel).where(
-                        SessionModel.started_at < cutoff
-                    )
+                    stmt = delete(SessionModel).where(SessionModel.started_at < cutoff)
                     res = await db.execute(stmt)
                     await db.commit()
                     deleted_count = res.rowcount or 0
@@ -87,12 +87,10 @@ async def prune_old_sessions(
                                 f"to enforce max sessions limit of {limit}."
                             )
                 except ValueError:
-                    logger.warning(
-                        f"Invalid max sessions value: {max_sessions_raw}"
-                    )
+                    logger.warning(f"Invalid max sessions value: {max_sessions_raw}")
 
             if total_pruned > 0 and vacuum:
-                await vacuum_database()
+                await database.vacuum_database()
         except Exception as e:
             logger.error(f"Error during database session pruning: {e}")
             await db.rollback()

--- a/packages/server/routers/sessions.py
+++ b/packages/server/routers/sessions.py
@@ -1,12 +1,13 @@
 import uuid
 from datetime import datetime, timezone
-from typing import Any, Dict, List
+from typing import Any, Dict, List, Optional
 
 from database import get_db
 from fastapi import APIRouter, Depends, HTTPException, Query, status
 from graph_layout import compute_graph_layout
 from models import EventModel, SessionModel
 from pricing import calculate_cost as _calculate_llm_cost
+from retention import prune_old_sessions
 from schemas import (
     AgentStats,
     EventResponse,
@@ -441,3 +442,29 @@ async def import_session(
     await manager.broadcast_session_update(db_session.session_id, session_data)
 
     return db_session
+
+
+@router.post("/prune", response_model=Dict[str, Any])
+async def prune_sessions(
+    retention_days: Optional[int] = Query(
+        None, description="Prune sessions older than N days"
+    ),
+    max_sessions: Optional[int] = Query(
+        None, description="Prune oldest sessions if total count exceeds N"
+    ),
+    vacuum: bool = Query(
+        True, description="Execute SQLite auto-vacuum after pruning"
+    ),
+):
+    """Manually trigger session retention pruning and SQLite auto-vacuum."""
+    pruned = await prune_old_sessions(
+        retention_days=retention_days,
+        max_sessions=max_sessions,
+        vacuum=vacuum,
+    )
+    return {
+        "status": "success",
+        "pruned_sessions": pruned,
+        "vacuum_executed": vacuum and pruned > 0,
+    }
+

--- a/packages/server/routers/sessions.py
+++ b/packages/server/routers/sessions.py
@@ -452,9 +452,7 @@ async def prune_sessions(
     max_sessions: Optional[int] = Query(
         None, description="Prune oldest sessions if total count exceeds N"
     ),
-    vacuum: bool = Query(
-        True, description="Execute SQLite auto-vacuum after pruning"
-    ),
+    vacuum: bool = Query(True, description="Execute SQLite auto-vacuum after pruning"),
 ):
     """Manually trigger session retention pruning and SQLite auto-vacuum."""
     pruned = await prune_old_sessions(
@@ -467,4 +465,3 @@ async def prune_sessions(
         "pruned_sessions": pruned,
         "vacuum_executed": vacuum and pruned > 0,
     }
-

--- a/packages/server/tests/conftest.py
+++ b/packages/server/tests/conftest.py
@@ -3,6 +3,16 @@ import sys
 
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 
+if "mem0" not in sys.modules:
+    try:
+        import mem0  # noqa: F401
+    except Exception:
+        from unittest.mock import MagicMock
+
+        mock_mem0 = MagicMock()
+        mock_mem0.MemoryClient = MagicMock
+        sys.modules["mem0"] = mock_mem0
+
 import database
 import main
 import pytest_asyncio
@@ -35,6 +45,12 @@ async def db_engine():
     )
     database.async_session_maker = test_session_maker
     main.async_session_maker = test_session_maker
+    try:
+        import retention
+
+        retention.async_session_maker = test_session_maker
+    except ImportError:
+        pass
     async with engine.begin() as conn:
         await conn.run_sync(Base.metadata.create_all)
     yield engine

--- a/packages/server/tests/test_retention.py
+++ b/packages/server/tests/test_retention.py
@@ -1,0 +1,13 @@
+import asyncio
+
+from retention import prune_old_sessions
+
+
+def test_prune_old_sessions_noop_when_no_config(monkeypatch):
+    monkeypatch.delenv("AGENTSCOPE_RETENTION_DAYS", raising=False)
+    monkeypatch.delenv("RETENTION_DAYS", raising=False)
+    monkeypatch.delenv("AGENTSCOPE_MAX_SESSIONS", raising=False)
+    monkeypatch.delenv("MAX_SESSIONS", raising=False)
+
+    pruned = asyncio.run(prune_old_sessions())
+    assert pruned == 0


### PR DESCRIPTION
### Summary of Changes

Fixes #102

- **SQLite Auto-Vacuum**: Enabled `PRAGMA auto_vacuum = FULL;` in SQLite connection pragmas (`packages/server/database.py`) and added `vacuum_database()` utility to execute `VACUUM;` to reclaim disk space after pruning operations.
- **Configurable Retention Policies**: Created `packages/server/retention.py` supporting both age-based pruning (`AGENTSCOPE_RETENTION_DAYS` / `RETENTION_DAYS`) and count-based pruning (`AGENTSCOPE_MAX_SESSIONS` / `MAX_SESSIONS`).
- **Periodic Background Cleanup**: Integrated periodic cleanup task into FastAPI `lifespan` in `packages/server/main.py` (configurable interval via `AGENTSCOPE_PRUNE_INTERVAL_SECONDS`, defaulting to 3600s).
- **Manual Prune Endpoint**: Added `POST /api/sessions/prune` in `packages/server/routers/sessions.py` allowing manual triggering of session retention pruning with optional immediate vacuuming.
- **Unit Testing**: Added test coverage in `packages/server/tests/test_retention.py`.
