### PR TITLE
feat(server,ops): add PostgreSQL storage backend support

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,39 @@
+# ==========================================
+# AgentScope Environment Configuration
+# ==========================================
+
+# Server Host & Port
+PORT=8765
+HOST=0.0.0.0
+
+# ------------------------------------------
+# Database Storage Backend
+# ------------------------------------------
+# Option 1: SQLite (Default zero-configuration local file)
+DATABASE_URL=sqlite+aiosqlite:///./agentscope.db
+
+# Option 2: PostgreSQL (Enterprise / Production)
+# Format: postgresql+asyncpg://<user>:<password>@<host>:<port>/<dbname>
+# Standard scheme (postgresql://...) is also automatically normalized to asyncpg.
+# DATABASE_URL=postgresql+asyncpg://postgres:postgres@localhost:5432/agentscope
+
+# PostgreSQL Connection Pooling (Optional)
+# DB_POOL_SIZE=10
+# DB_MAX_OVERFLOW=20
+
+# ------------------------------------------
+# Retention & Pruning (Optional)
+# ------------------------------------------
+# AGENTSCOPE_RETENTION_DAYS=30
+# AGENTSCOPE_MAX_SESSIONS=1000
+# AGENTSCOPE_PRUNE_INTERVAL_SECONDS=3600
+
+# ------------------------------------------
+# Security & Networking (Optional)
+# ------------------------------------------
+# CORS_ALLOW_ORIGINS=http://localhost:3000
+
+# ------------------------------------------
+# Mem0 Integration (Optional)
+# ------------------------------------------
+# MEM0_API_KEY=your_mem0_api_key

--- a/README.md
+++ b/README.md
@@ -102,6 +102,13 @@ npm run dev
 pip install agentscope
 ```
 
+### Storage Backends (SQLite & PostgreSQL)
+
+AgentScope supports both **SQLite** (default zero-config) and **PostgreSQL** via `asyncpg`:
+
+- **SQLite (Default)**: `sqlite+aiosqlite:///./agentscope.db`
+- **PostgreSQL**: Set `DATABASE_URL=postgresql+asyncpg://user:pass@localhost:5432/agentscope` in your `.env` or `docker-compose.yml`. Standard PostgreSQL URIs (`postgresql://...`) are also automatically normalized to use `asyncpg`.
+
 ### Instrument Your Code
 
 Now, just drop the callback into your code!

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,7 +13,13 @@ services:
       - sqlite_data:/app/data
     environment:
       - DATABASE_URL=sqlite+aiosqlite:////app/data/agentscope.db
+      # To use PostgreSQL instead of SQLite:
+      # - DATABASE_URL=postgresql+asyncpg://postgres:postgres@postgres:5432/agentscope
     restart: unless-stopped
+    # Uncomment if using the postgres service below:
+    # depends_on:
+    #   postgres:
+    #     condition: service_healthy
 
   ui:
     build:
@@ -30,5 +36,25 @@ services:
       - server
     restart: unless-stopped
 
+  # Optional PostgreSQL storage backend (Issue #93)
+  # postgres:
+  #   image: postgres:16-alpine
+  #   container_name: agentscope-postgres
+  #   restart: unless-stopped
+  #   environment:
+  #     - POSTGRES_USER=postgres
+  #     - POSTGRES_PASSWORD=postgres
+  #     - POSTGRES_DB=agentscope
+  #   ports:
+  #     - "5432:5432"
+  #   volumes:
+  #     - pg_data:/var/lib/postgresql/data
+  #   healthcheck:
+  #     test: ["CMD-SHELL", "pg_isready -U postgres -d agentscope"]
+  #     interval: 5s
+  #     timeout: 5s
+  #     retries: 5
+
 volumes:
   sqlite_data:
+  # pg_data:

--- a/packages/server/.env.example
+++ b/packages/server/.env.example
@@ -1,0 +1,39 @@
+# ==========================================
+# AgentScope Server Environment Configuration
+# ==========================================
+
+# Server Host & Port
+PORT=8765
+HOST=0.0.0.0
+
+# ------------------------------------------
+# Database Storage Backend
+# ------------------------------------------
+# Option 1: SQLite (Default zero-configuration local file)
+DATABASE_URL=sqlite+aiosqlite:///./agentscope.db
+
+# Option 2: PostgreSQL (Enterprise / Production)
+# Format: postgresql+asyncpg://<user>:<password>@<host>:<port>/<dbname>
+# Standard scheme (postgresql://...) is also automatically normalized to asyncpg.
+# DATABASE_URL=postgresql+asyncpg://postgres:postgres@localhost:5432/agentscope
+
+# PostgreSQL Connection Pooling (Optional)
+# DB_POOL_SIZE=10
+# DB_MAX_OVERFLOW=20
+
+# ------------------------------------------
+# Retention & Pruning (Optional)
+# ------------------------------------------
+# AGENTSCOPE_RETENTION_DAYS=30
+# AGENTSCOPE_MAX_SESSIONS=1000
+# AGENTSCOPE_PRUNE_INTERVAL_SECONDS=3600
+
+# ------------------------------------------
+# Security & Networking (Optional)
+# ------------------------------------------
+# CORS_ALLOW_ORIGINS=http://localhost:3000
+
+# ------------------------------------------
+# Mem0 Integration (Optional)
+# ------------------------------------------
+# MEM0_API_KEY=your_mem0_api_key

--- a/packages/server/database.py
+++ b/packages/server/database.py
@@ -12,8 +12,34 @@ from sqlalchemy.orm import declarative_base
 # Default to local SQLite file
 DATABASE_URL = os.getenv("DATABASE_URL", "sqlite+aiosqlite:///./agentscope.db")
 
+# Normalize PostgreSQL schemes to asyncpg if standard scheme provided
+if DATABASE_URL.startswith("postgresql://"):
+    DATABASE_URL = DATABASE_URL.replace("postgresql://", "postgresql+asyncpg://", 1)
+elif DATABASE_URL.startswith("postgres://"):
+    DATABASE_URL = DATABASE_URL.replace("postgres://", "postgresql+asyncpg://", 1)
+
+# Configure engine options based on dialect
+engine_kwargs = {"echo": False}
+if DATABASE_URL.startswith("postgresql+asyncpg://"):
+    try:
+        pool_size = int(os.getenv("DB_POOL_SIZE", "10"))
+    except ValueError:
+        pool_size = 10
+    try:
+        max_overflow = int(os.getenv("DB_MAX_OVERFLOW", "20"))
+    except ValueError:
+        max_overflow = 20
+
+    engine_kwargs.update(
+        {
+            "pool_pre_ping": True,
+            "pool_size": pool_size,
+            "max_overflow": max_overflow,
+        }
+    )
+
 # Create asynchronous engine
-engine = create_async_engine(DATABASE_URL, echo=False)
+engine = create_async_engine(DATABASE_URL, **engine_kwargs)
 
 
 # Listen to connect event to configure SQLite options (WAL & Foreign Keys)

--- a/packages/server/requirements.txt
+++ b/packages/server/requirements.txt
@@ -7,5 +7,6 @@ python-dotenv>=1.2.3
 aiosqlite>=0.22.1
 greenlet
 mem0ai>=2.0.19
+asyncpg>=0.29.0
 
 


### PR DESCRIPTION
### Summary of Changes

Fixes #93

- **PostgreSQL Async Driver**: Added `asyncpg>=0.29.0` dependency to `packages/server/requirements.txt` enabling production-grade asynchronous PostgreSQL connectivity.
- **Connection URI Normalization & Pooling**: In `packages/server/database.py`, added automatic URL normalization from `postgresql://` or `postgres://` to `postgresql+asyncpg://`, and configured asynchronous connection pool settings (`pool_pre_ping=True`, configurable `pool_size` and `max_overflow`).
- **Docker Compose Service**: Added commented, production-ready `postgres:16-alpine` service with volume mapping, healthchecks, and environment configuration in `docker-compose.yml`.
- **Environment Documentation**: Added root and server `.env.example` templates documenting PostgreSQL connection strings alongside default SQLite configuration.
- **Documentation**: Updated `README.md` with instructions on configuring the PostgreSQL storage backend.
