### PR TITLE
feat(ui,server): add category tags input and pills for session memories

### DIFF
--- a/packages/server/routers/memories.py
+++ b/packages/server/routers/memories.py
@@ -1,4 +1,4 @@
-from typing import Any, Dict, Optional
+from typing import Any, Dict, List, Optional
 
 from fastapi import APIRouter, HTTPException, status
 from mem0_integration import get_mem0_client
@@ -10,6 +10,7 @@ router = APIRouter(prefix="/sessions/{session_id}/memories", tags=["memories"])
 class MemoryCreateRequest(BaseModel):
     text: str
     metadata: Optional[Dict[str, Any]] = None
+    categories: Optional[List[str]] = None
 
 
 class MemorySearchRequest(BaseModel):
@@ -49,8 +50,18 @@ async def add_session_memory(session_id: str, payload: MemoryCreateRequest):
     """Manually add a memory to this session."""
     client = verify_mem0_client()
     try:
-        metadata = payload.metadata or {}
-        res = client.add(payload.text, user_id=session_id, metadata=metadata)
+        metadata = dict(payload.metadata or {})
+        if payload.categories:
+            metadata["categories"] = payload.categories
+        try:
+            res = client.add(
+                payload.text,
+                user_id=session_id,
+                metadata=metadata,
+                categories=payload.categories,
+            )
+        except TypeError:
+            res = client.add(payload.text, user_id=session_id, metadata=metadata)
         return res
     except Exception as e:
         raise HTTPException(

--- a/packages/server/routers/memories.py
+++ b/packages/server/routers/memories.py
@@ -51,16 +51,18 @@ async def add_session_memory(session_id: str, payload: MemoryCreateRequest):
     client = verify_mem0_client()
     try:
         metadata = dict(payload.metadata or {})
-        if payload.categories:
+        if payload.categories is not None:
             metadata["categories"] = payload.categories
-        try:
-            res = client.add(
-                payload.text,
-                user_id=session_id,
-                metadata=metadata,
-                categories=payload.categories,
-            )
-        except TypeError:
+            try:
+                res = client.add(
+                    payload.text,
+                    user_id=session_id,
+                    metadata=metadata,
+                    categories=payload.categories,
+                )
+            except TypeError:
+                res = client.add(payload.text, user_id=session_id, metadata=metadata)
+        else:
             res = client.add(payload.text, user_id=session_id, metadata=metadata)
         return res
     except Exception as e:

--- a/packages/server/tests/test_memories.py
+++ b/packages/server/tests/test_memories.py
@@ -53,6 +53,27 @@ async def test_memories_api(mock_mem0_client):
             "User likes programming", user_id=session_id, metadata={"tag": "code"}
         )
 
+    # 2b. Test add with categories
+    mock_mem0_client.add.reset_mock()
+    mock_mem0_client.add.return_value = {"event_id": "evt-cat", "status": "PENDING"}
+    async with AsyncClient(
+        transport=ASGITransport(app=app), base_url="http://test"
+    ) as ac:
+        res = await ac.post(
+            f"/api/sessions/{session_id}/memories",
+            json={
+                "text": "User prefers dark mode",
+                "categories": ["preferences", "ui"],
+            },
+        )
+        assert res.status_code == 200
+        mock_mem0_client.add.assert_called_once_with(
+            "User prefers dark mode",
+            user_id=session_id,
+            metadata={"categories": ["preferences", "ui"]},
+            categories=["preferences", "ui"],
+        )
+
     # 3. Test search
     mock_mem0_client.search.return_value = {
         "results": [{"id": "mem-2", "memory": "relevant memory"}]

--- a/packages/ui/app/page.tsx
+++ b/packages/ui/app/page.tsx
@@ -25,6 +25,7 @@ import {
   Brain,
   Download,
   Upload,
+  Tag,
 } from "lucide-react";
 
 const API_BASE = process.env.NEXT_PUBLIC_API_URL || "http://127.0.0.1:8765";
@@ -60,6 +61,7 @@ export default function Dashboard() {
   const [memoryQuery, setMemoryQuery] = useState("");
   const [isSearchingMemories, setIsSearchingMemories] = useState(false);
   const [newMemoryText, setNewMemoryText] = useState("");
+  const [newMemoryCategories, setNewMemoryCategories] = useState("");
   const [isAddingMemory, setIsAddingMemory] = useState(false);
   const [mem0Error, setMem0Error] = useState<string | null>(null);
 
@@ -289,16 +291,27 @@ export default function Dashboard() {
     try {
       setIsAddingMemory(true);
       setMem0Error(null);
+      const parsedCategories = newMemoryCategories
+        .split(",")
+        .map((c) => c.trim())
+        .filter(Boolean);
+      const payload: { text: string; categories?: string[] } = {
+        text: newMemoryText,
+      };
+      if (parsedCategories.length > 0) {
+        payload.categories = parsedCategories;
+      }
       const res = await fetch(
         getApiUrl(`/api/sessions/${activeSession.session_id}/memories`),
         {
           method: "POST",
           headers: { "Content-Type": "application/json" },
-          body: JSON.stringify({ text: newMemoryText }),
+          body: JSON.stringify(payload),
         }
       );
       if (res.ok) {
         setNewMemoryText("");
+        setNewMemoryCategories("");
         setTimeout(fetchMemories, 1000);
       } else {
         const errData = await res.json();
@@ -974,18 +987,25 @@ export default function Dashboard() {
                   </form>
 
                   {/* Add Memory */}
-                  <form onSubmit={handleAddMemory} className="glass-panel p-4 rounded-2xl border border-border flex items-center gap-3 bg-card/40">
+                  <form onSubmit={handleAddMemory} className="glass-panel p-4 rounded-2xl border border-border flex flex-col sm:flex-row items-center gap-3 bg-card/40">
                     <input
                       type="text"
                       placeholder="Add a new custom memory..."
                       value={newMemoryText}
                       onChange={(e) => setNewMemoryText(e.target.value)}
-                      className="flex-1 bg-secondary/40 text-xs px-3 py-2 rounded-xl border border-border focus:outline-none focus:border-purple-500/50 text-white"
+                      className="flex-1 w-full bg-secondary/40 text-xs px-3 py-2 rounded-xl border border-border focus:outline-none focus:border-purple-500/50 text-white"
+                    />
+                    <input
+                      type="text"
+                      placeholder="Categories (e.g. preferences, facts)..."
+                      value={newMemoryCategories}
+                      onChange={(e) => setNewMemoryCategories(e.target.value)}
+                      className="w-full sm:w-60 bg-secondary/40 text-xs px-3 py-2 rounded-xl border border-border focus:outline-none focus:border-purple-500/50 text-white"
                     />
                     <button
                       type="submit"
                       disabled={isAddingMemory || !newMemoryText.trim()}
-                      className="px-4 py-2 rounded-xl bg-purple-600 hover:bg-purple-700 font-bold text-xs text-white transition-all duration-200 disabled:opacity-50"
+                      className="w-full sm:w-auto px-4 py-2 rounded-xl bg-purple-600 hover:bg-purple-700 font-bold text-xs text-white transition-all duration-200 disabled:opacity-50 whitespace-nowrap"
                     >
                       {isAddingMemory ? "Adding..." : "Add Memory"}
                     </button>
@@ -1040,10 +1060,21 @@ export default function Dashboard() {
                                     Agent: {agentName}
                                   </span>
                                 )}
-                                {m.categories && m.categories.length > 0 && (
-                                  <span className="bg-blue-900/30 text-blue-300 border border-blue-500/20 px-2 py-0.5 rounded-md">
-                                    {m.categories.join(", ")}
-                                  </span>
+                                {((m.categories && m.categories.length > 0) ||
+                                  (m.metadata?.categories && m.metadata.categories.length > 0)) && (
+                                  <div className="flex flex-wrap items-center gap-1">
+                                    {(m.categories || m.metadata?.categories).map(
+                                      (cat: string, idx: number) => (
+                                        <span
+                                          key={idx}
+                                          className="bg-blue-900/30 text-blue-300 border border-blue-500/20 px-2 py-0.5 rounded-md flex items-center gap-1"
+                                        >
+                                          <Tag className="w-2.5 h-2.5" />
+                                          {cat}
+                                        </span>
+                                      )
+                                    )}
+                                  </div>
                                 )}
                               </div>
                               <button

--- a/packages/ui/types/index.ts
+++ b/packages/ui/types/index.ts
@@ -129,3 +129,15 @@ export interface StatsResponse {
   agents: AgentStats[];
   token_timeline: TokenTimelinePoint[];
 }
+
+export interface MemoryItem {
+  id?: string;
+  memory?: string;
+  text?: string;
+  categories?: string[];
+  metadata?: Record<string, any>;
+  created_at?: string;
+  updated_at?: string;
+  score?: number;
+}
+


### PR DESCRIPTION
### Summary of Changes

Fixes #123

- **Server Memory Categories Support**: Updated `MemoryCreateRequest` in `packages/server/routers/memories.py` to accept optional `categories: Optional[List[str]] = None` and forwarded categories both directly to Mem0 and inside the metadata dictionary.
- **UI Category Tags Input**: Added a category tags input field in the Add Memory form in `packages/ui/app/page.tsx` with comma-separated tag parsing and form state reset.
- **Category Badge Pills**: Rendered tagged badges with the `Tag` icon in the memory cards viewer (`packages/ui/app/page.tsx`) to clearly distinguish memory categories.
- **Type Definitions**: Added `MemoryItem` interface with categories and metadata attributes in `packages/ui/types/index.ts`.
