### PR TITLE
feat(sdk): optional tiktoken integration for local fallback token counting

### DIFF
--- a/packages/sdk/agentscope/__init__.py
+++ b/packages/sdk/agentscope/__init__.py
@@ -3,5 +3,12 @@
 from agentscope.callback import AgentScopeCallback
 from agentscope.decorators import trace
 from agentscope.exceptions import AgentScopeError, BudgetExceededError
+from agentscope.token_counter import estimate_tokens
 
-__all__ = ["AgentScopeCallback", "trace", "AgentScopeError", "BudgetExceededError"]
+__all__ = [
+    "AgentScopeCallback",
+    "trace",
+    "AgentScopeError",
+    "BudgetExceededError",
+    "estimate_tokens",
+]

--- a/packages/sdk/agentscope/callback.py
+++ b/packages/sdk/agentscope/callback.py
@@ -7,6 +7,7 @@ from uuid import UUID
 from agentscope._pricing import calculate_cost
 from agentscope.client import AgentScopeClient
 from agentscope.exceptions import BudgetExceededError
+from agentscope.token_counter import estimate_tokens
 
 # Gracefully handle missing langchain-core dependencies
 try:
@@ -324,6 +325,24 @@ class AgentScopeCallback(AsyncCallbackHandler):
                         if (prompt_tokens is not None and completion_tokens is not None)
                         else None
                     )
+
+            # Fallback to local token estimation if model metrics are empty
+            if prompt_tokens is None or prompt_tokens == 0:
+                if prompts:
+                    prompt_text = (
+                        "\n".join(prompts)
+                        if isinstance(prompts, list)
+                        else str(prompts)
+                    )
+                    prompt_tokens = estimate_tokens(prompt_text, model)
+
+            if completion_tokens is None or completion_tokens == 0:
+                if completion:
+                    completion_tokens = estimate_tokens(completion, model)
+
+            if total_tokens is None or total_tokens == 0:
+                if prompt_tokens is not None or completion_tokens is not None:
+                    total_tokens = (prompt_tokens or 0) + (completion_tokens or 0)
 
             # Calculate and accumulate cost
             call_cost = calculate_cost(model, prompt_tokens, completion_tokens)

--- a/packages/sdk/agentscope/token_counter.py
+++ b/packages/sdk/agentscope/token_counter.py
@@ -1,0 +1,32 @@
+import math
+from typing import Optional
+
+
+def estimate_tokens(text: Optional[str], model_name: str = "gpt-4o") -> int:
+    """Estimate token count for a text string using tiktoken if available.
+
+    Falls back to a character heuristic (~4 chars/token) if tiktoken is
+    not installed.
+
+    Args:
+        text: The prompt or completion text to tokenize.
+        model_name: Name of the model for tiktoken encoding lookup.
+
+    Returns:
+        Estimated non-negative integer token count.
+    """
+    if not text:
+        return 0
+
+    try:
+        import tiktoken
+
+        try:
+            encoding = tiktoken.encoding_for_model(model_name)
+        except Exception:
+            encoding = tiktoken.get_encoding("cl100k_base")
+
+        return len(encoding.encode(text))
+    except (ImportError, Exception):
+        # Fallback estimation heuristic: ~4 characters per token
+        return max(1, math.ceil(len(text) / 4.0))

--- a/packages/sdk/pyproject.toml
+++ b/packages/sdk/pyproject.toml
@@ -22,6 +22,9 @@ dependencies = [
 agentscope = "agentscope.cli:main"
 
 [project.optional-dependencies]
+tiktoken = [
+    "tiktoken>=0.7.0",
+]
 langchain = [
     "langchain-core>=1.6.1",
 ]

--- a/packages/sdk/tests/test_fallback_tokens.py
+++ b/packages/sdk/tests/test_fallback_tokens.py
@@ -1,0 +1,56 @@
+from unittest.mock import MagicMock
+
+import pytest
+
+from agentscope.callback import AgentScopeCallback
+from agentscope.token_counter import estimate_tokens
+
+
+def test_estimate_tokens_with_text():
+    sample_text = "Hello world, this is a test prompt for local token estimation."
+    count = estimate_tokens(sample_text, "gpt-4o")
+    assert count > 0
+    assert isinstance(count, int)
+
+
+def test_estimate_tokens_empty():
+    assert estimate_tokens("", "gpt-4o") == 0
+    assert estimate_tokens(None, "gpt-4o") == 0
+
+
+@pytest.mark.asyncio
+async def test_on_llm_end_fallback_tokens_when_empty_usage():
+    callback = AgentScopeCallback()
+    callback.client = MagicMock()
+
+    run_id = MagicMock()
+    callback._run_metadata[run_id] = {
+        "agent_name": "LocalAgent",
+        "agent_type": "llm",
+        "model": "ollama/llama3",
+        "prompts": ["What is the capital of France?"],
+        "temperature": 0.7,
+        "streaming": False,
+    }
+
+    # Response with no llm_output or empty token_usage
+    fake_generation = MagicMock()
+    fake_generation.text = "The capital of France is Paris."
+    fake_response = MagicMock()
+    fake_response.generations = [[fake_generation]]
+    fake_response.llm_output = {}
+
+    await callback.on_llm_end(fake_response, run_id=run_id)
+
+    assert callback.client.emit.called
+    emitted_event = callback.client.emit.call_args[0][0]
+    payload = emitted_event["payload"]
+
+    assert payload["prompt_tokens"] is not None
+    assert payload["prompt_tokens"] > 0
+    assert payload["completion_tokens"] is not None
+    assert payload["completion_tokens"] > 0
+    assert (
+        payload["total_tokens"]
+        == payload["prompt_tokens"] + payload["completion_tokens"]
+    )


### PR DESCRIPTION
## Summary
Adds an optional `tiktoken` dependency and fallback tokenizer in the `agentscope-sdk` package to estimate token usage and costs when local model endpoints (e.g. Ollama or local LLM deployments) return empty/null token metrics.

## Problem
When using local LLM inference engines that do not return token usage objects (`prompt_tokens`, `completion_tokens`), `AgentScopeCallback` records `None` or `0` for token metrics and `$0.00` cumulative cost.

## Solution
1. **Optional Dependency**: Added `tiktoken` under `[project.optional-dependencies]` in `packages/sdk/pyproject.toml`.
2. **Fallback Tokenizer (`agentscope.token_counter`)**: Created `estimate_tokens(text, model_name)` which uses `tiktoken` (falling back to `cl100k_base` encoding or character heuristic if tiktoken is not installed).
3. **Callback Integration**: Updated `AgentScopeCallback.on_llm_end` in `packages/sdk/agentscope/callback.py` to estimate prompt and completion tokens when model response usage objects are empty, allowing cost calculation (`calculate_cost`) to function seamlessly.

## Testing
- **New Unit Tests**:
  - `packages/sdk/tests/test_fallback_tokens.py`: Verified `estimate_tokens` logic, empty string handling, and fallback token metric generation when `llm_output` is empty.
- **Automated Verification**:
  - `pytest`: All 19 SDK tests passed (`19 passed in 1.21s`).
  - `ruff check`: All checks passed.
  - `black`: Code formatted cleanly.

Closes #100
